### PR TITLE
Categorization of assignment statement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,19 +7,19 @@ matrix:
   include:
   - compiler: gcc
     env:
-    - CXX_COMPILER=g++-4.9
-    - CC_COMPILER=gcc-4.9
-    - FC_COMPILER=gfortran-4.9
-    - OMPI_CC=gcc-4.9
-    - OMPI_FC=gfortran-4.9
+    - CXX_COMPILER=g++-5
+    - CC_COMPILER=gcc-5
+    - FC_COMPILER=gfortran-5
+    - OMPI_CC=gcc-5
+    - OMPI_FC=gfortran-5
     addons:
       apt:
         sources:
         - ubuntu-toolchain-r-test
         packages:
-        - gcc-4.9
-        - g++-4.9
-        - gfortran-4.9
+        - gcc-5
+        - g++-5
+        - gfortran-5
         - ant
         - ant-optional
         - cabal-install

--- a/cx2t/src/claw/tatsu/primitive/Condition.java
+++ b/cx2t/src/claw/tatsu/primitive/Condition.java
@@ -8,6 +8,7 @@ import claw.tatsu.xcodeml.xnode.common.Xcode;
 import claw.tatsu.xcodeml.xnode.common.Xnode;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * Primitive analysis and transformation on condition node. This included:
@@ -28,7 +29,7 @@ public final class Condition {
    * @return True if the condition depend on a variable in the list. False
    * otherwise.
    */
-  public static boolean dependsOn(Xnode condition, List<String> variables) {
+  public static boolean dependsOn(Xnode condition, Set<String> variables) {
     if(condition == null || condition.opcode() != Xcode.CONDITION
         || variables.isEmpty())
     {

--- a/cx2t/src/claw/tatsu/primitive/Condition.java
+++ b/cx2t/src/claw/tatsu/primitive/Condition.java
@@ -1,0 +1,47 @@
+/*
+ * This file is released under terms of BSD license
+ * See LICENSE file for more information
+ */
+package claw.tatsu.primitive;
+
+import claw.tatsu.xcodeml.xnode.common.Xcode;
+import claw.tatsu.xcodeml.xnode.common.Xnode;
+
+import java.util.List;
+
+/**
+ * Primitive analysis and transformation on condition node. This included:
+ * - Check condition dependency on certain variables.
+ *
+ * @author clementval
+ */
+public final class Condition {
+
+  // Avoid instantiation of this class
+  private Condition() {
+  }
+
+  /**
+   * Check whether the condition depends on some variables.
+   *
+   * @param variables List of variable name.
+   * @return True if the condition depend on a variable in the list. False
+   * otherwise.
+   */
+  public static boolean dependsOn(Xnode condition, List<String> variables) {
+    if(condition == null || condition.opcode() != Xcode.CONDITION
+        || variables.isEmpty())
+    {
+      return false;
+    }
+    List<Xnode> varRefs = condition.matchAll(Xcode.VAR_REF);
+    for(Xnode varRef : varRefs) {
+      String varName = varRef.matchSeq(Xcode.VAR).value();
+      if(variables.contains(varName)){
+        return true;
+      }
+    }
+    return false;
+  }
+
+}

--- a/cx2t/src/claw/tatsu/primitive/Function.java
+++ b/cx2t/src/claw/tatsu/primitive/Function.java
@@ -4,6 +4,7 @@
  */
 package claw.tatsu.primitive;
 
+import claw.tatsu.xcodeml.abstraction.AssignStatement;
 import claw.tatsu.xcodeml.abstraction.DimensionDefinition;
 import claw.tatsu.xcodeml.abstraction.InsertionPosition;
 import claw.tatsu.xcodeml.abstraction.PromotionInfo;
@@ -13,6 +14,10 @@ import claw.tatsu.xcodeml.xnode.common.Xid;
 import claw.tatsu.xcodeml.xnode.common.Xnode;
 import claw.tatsu.xcodeml.xnode.fortran.FfunctionDefinition;
 import claw.tatsu.xcodeml.xnode.fortran.FfunctionType;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Primitive transformation, test and utility for Function related action.
@@ -119,5 +124,24 @@ public final class Function {
       }
     }
     return defaultInfo;
+  }
+
+  /**
+   * Gather all assignment statements in the function definition.
+   * @param fctDef Function definition in which statements are gathered.
+   * @return List of assignment statement in AST order. Empty list if function
+   * definition is null or no statement found.
+   */
+  public static List<AssignStatement> gatherAssignStatements(
+      FfunctionDefinition fctDef)
+  {
+    if(fctDef == null || fctDef.body() == null) {
+      return Collections.emptyList();
+    }
+    List<AssignStatement> statements = new ArrayList<>();
+    for(Xnode n : fctDef.body().matchAll(Xcode.F_ASSIGN_STATEMENT)) {
+      statements.add(new AssignStatement(n.element()));
+    }
+    return statements;
   }
 }

--- a/cx2t/src/claw/tatsu/xcodeml/abstraction/AssignStatement.java
+++ b/cx2t/src/claw/tatsu/xcodeml/abstraction/AssignStatement.java
@@ -6,8 +6,12 @@ package claw.tatsu.xcodeml.abstraction;
 
 import claw.tatsu.xcodeml.xnode.common.Xcode;
 import claw.tatsu.xcodeml.xnode.common.Xnode;
-import claw.tatsu.xcodeml.xnode.fortran.FfunctionDefinition;
 import org.w3c.dom.Element;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Abstraction of assignment statement to be able to categorize them and
@@ -52,6 +56,7 @@ public class AssignStatement extends Xnode {
   /**
    * Check if the current assignment statement is a child of a give type of
    * node.
+   *
    * @param opcode Opcode of the ancestor to check for.
    * @return True if on of the ancestor is of the given kind. Search is
    * contained in the function definition itself.
@@ -69,6 +74,20 @@ public class AssignStatement extends Xnode {
       crt = crt.ancestor();
     }
     return false;
+  }
+
+  /**
+   * Get list of array variable names used in assignment statement.
+   *
+   * @return List of variables.
+   */
+  public Set<String> getVarRefNames() {
+    List<Xnode> varRefs = matchAll(Xcode.VAR_REF);
+    Set<String> names = new HashSet<>();
+    for(Xnode varRef : varRefs) {
+      names.add(varRef.matchSeq(Xcode.VAR).value());
+    }
+    return names;
   }
 
 }

--- a/cx2t/src/claw/tatsu/xcodeml/abstraction/AssignStatement.java
+++ b/cx2t/src/claw/tatsu/xcodeml/abstraction/AssignStatement.java
@@ -6,6 +6,7 @@ package claw.tatsu.xcodeml.abstraction;
 
 import claw.tatsu.xcodeml.xnode.common.Xcode;
 import claw.tatsu.xcodeml.xnode.common.Xnode;
+import claw.tatsu.xcodeml.xnode.fortran.FfunctionDefinition;
 import org.w3c.dom.Element;
 
 /**
@@ -46,6 +47,28 @@ public class AssignStatement extends Xnode {
    */
   public Xnode getLhs() {
     return child(Xnode.LHS);
+  }
+
+  /**
+   * Check if the current assignment statement is a child of a give type of
+   * node.
+   * @param opcode Opcode of the ancestor to check for.
+   * @return True if on of the ancestor is of the given kind. Search is
+   * contained in the function definition itself.
+   */
+  public boolean isChildOf(Xcode opcode) {
+    Xnode crt = this;
+    while(crt != null) {
+      if(crt.ancestor().opcode() == opcode) {
+        return true;
+      }
+      // Stop searching when FfunctionDefinition is reached
+      if(crt.ancestor().opcode() == Xcode.F_FUNCTION_DEFINITION) {
+        return false;
+      }
+      crt = crt.ancestor();
+    }
+    return false;
   }
 
 }

--- a/cx2t/src/claw/tatsu/xcodeml/abstraction/AssignStatement.java
+++ b/cx2t/src/claw/tatsu/xcodeml/abstraction/AssignStatement.java
@@ -1,0 +1,51 @@
+/*
+ * This file is released under terms of BSD license
+ * See LICENSE file for more information
+ */
+package claw.tatsu.xcodeml.abstraction;
+
+import claw.tatsu.xcodeml.xnode.common.Xcode;
+import claw.tatsu.xcodeml.xnode.common.Xnode;
+import org.w3c.dom.Element;
+
+/**
+ * Abstraction of assignment statement to be able to categorize them and
+ * easily extract some information.
+ *
+ * @author clementval
+ */
+public class AssignStatement extends Xnode {
+
+  /**
+   * Constructs an Xnode object from an element in the AST.
+   *
+   * @param element Base element for the Xnode object.
+   */
+  public AssignStatement(Element element) {
+    super(element);
+  }
+
+  /**
+   * Get the variable name on the left hand-side of the assignment.
+   *
+   * @return Left hand-side variable name.
+   */
+  public String getLhsName() {
+    Xnode lhs = getLhs();
+    if(lhs != null) {
+      return (lhs.opcode() == Xcode.VAR) ? lhs.value() :
+          lhs.matchSeq(Xcode.VAR_REF, Xcode.VAR).value();
+    }
+    return "";
+  }
+
+  /**
+   * Get the left hand-side node of the assignment.
+   *
+   * @return Left hans-side node.
+   */
+  public Xnode getLhs() {
+    return child(Xnode.LHS);
+  }
+
+}

--- a/cx2t/src/claw/tatsu/xcodeml/xnode/common/Xnode.java
+++ b/cx2t/src/claw/tatsu/xcodeml/xnode/common/Xnode.java
@@ -448,9 +448,15 @@ public class Xnode {
    * @return Ancestor node if any. Null otherwise.
    */
   public Xnode ancestor() {
-    if(_baseElement == null) {
+    if(_baseElement == null || _baseElement.getParentNode() == null) {
       return null;
     }
+
+    // Reach document root stop here
+    if(_baseElement.getParentNode().getNodeType() == Node.DOCUMENT_NODE) {
+      return null;
+    }
+
     return new Xnode((Element) _baseElement.getParentNode());
   }
 
@@ -519,6 +525,40 @@ public class Xnode {
    */
   public Xnode matchSibling(Xcode opcode) {
     return universalMatch(opcode, true);
+  }
+
+  /**
+   * Find nodes with the given opcode in the ancestors of the current node.
+   *
+   * @param opcode Opcode of the node to be matched.
+   * @return List of matched node. Empty list if nothing matched.
+   */
+  public List<Xnode> matchAllAncestor(Xcode opcode) {
+    return matchAllAncestor(opcode, null);
+  }
+
+  /**
+   * Find nodes with the given opcode in the ancestors of the current node.
+   *
+   * @param opcode   Opcode of the node to be matched.
+   * @param stopCode Stop searching if given opcode is reached. If null, search
+   *                 until root node.
+   * @return List of matched node. Empty list if nothing matched.
+   */
+  public List<Xnode> matchAllAncestor(Xcode opcode, Xcode stopCode) {
+    List<Xnode> statements = new ArrayList<>();
+    Xnode crt = this;
+    while(crt != null && crt.ancestor() != null) {
+      if(crt.ancestor().opcode() == opcode) {
+        statements.add(crt.ancestor());
+      }
+      // Stop searching when FfunctionDefinition is reached
+      if(stopCode != null && crt.ancestor().opcode() == stopCode) {
+        return statements;
+      }
+      crt = crt.ancestor();
+    }
+    return statements;
   }
 
   /**

--- a/cx2t/src/claw/tatsu/xcodeml/xnode/common/Xnode.java
+++ b/cx2t/src/claw/tatsu/xcodeml/xnode/common/Xnode.java
@@ -968,6 +968,6 @@ public class Xnode {
   @Override
   public boolean equals(Object o) {
     return !(o == null || !(o instanceof Xnode))
-        && _baseElement.equals(o);
+        && element() == ((Xnode) o).element();
   }
 }

--- a/cx2t/src/claw/tatsu/xcodeml/xnode/common/Xnode.java
+++ b/cx2t/src/claw/tatsu/xcodeml/xnode/common/Xnode.java
@@ -799,12 +799,6 @@ public class Xnode {
     return false;
   }
 
-  @Override
-  public boolean equals(Object obj) {
-    return !(obj == null || !(obj instanceof Xnode))
-        && element() == ((Xnode) obj).element();
-  }
-
   /**
    * Return type hash associated with this node if any.
    *
@@ -964,5 +958,16 @@ public class Xnode {
   public String toString() {
     return String.format("%s (children: %d)", opcode().code(),
         children().size());
+  }
+
+  @Override
+  public int hashCode() {
+    return _baseElement.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return !(o == null || !(o instanceof Xnode))
+        && _baseElement.equals(o);
   }
 }

--- a/cx2t/src/claw/wani/transformation/sca/Parallelize.java
+++ b/cx2t/src/claw/wani/transformation/sca/Parallelize.java
@@ -491,6 +491,8 @@ public class Parallelize extends ClawTransformation {
       String lhsName = assign.getLhsName();
       NestedDoStatement loops = null;
 
+
+      // Check if assignment is dependant of an if statement.
       if(assign.isChildOf(Xcode.F_IF_STATEMENT)) {
 
         // Gather all potential ancestor if statements
@@ -516,7 +518,9 @@ public class Parallelize extends ClawTransformation {
           loops.getInnerStatement().body().append(hookIfStmt, true);
           hookIfStmt.delete();
         }
-        continue;
+        continue; // TODO this must be merged with the rest of the code below
+        // the special cases must be there as well
+
       }
 
       if(lhs.opcode() == Xcode.F_ARRAY_REF &&

--- a/cx2t/src/claw/wani/transformation/sca/Parallelize.java
+++ b/cx2t/src/claw/wani/transformation/sca/Parallelize.java
@@ -524,6 +524,14 @@ public class Parallelize extends ClawTransformation {
             }
           }
           hooks.add(hookIfStmt);
+        } else {
+          Iterator<Xnode> iter = hooks.iterator();
+          while (iter.hasNext()) {
+            if(assign.isNestedIn(iter.next())) {
+              wrapInDoStatement = false;
+              break;
+            }
+          }
         }
       }
 

--- a/cx2t/src/claw/wani/transformation/sca/Parallelize.java
+++ b/cx2t/src/claw/wani/transformation/sca/Parallelize.java
@@ -413,7 +413,8 @@ public class Parallelize extends ClawTransformation {
             Directive.findParallelRegionEnd(_fctDef, null);
 
         // Define a hook from where we can insert the new do statement
-        Xnode hook = parallelRegionEnd.nextSibling();
+        Xnode hook = parallelRegionEnd != null
+            ? parallelRegionEnd.nextSibling() : null;
         Body.shiftIn(parallelRegionStart, parallelRegionEnd,
             loops.getInnerStatement().body(), true);
 

--- a/cx2t/src/claw/wani/transformation/sca/Parallelize.java
+++ b/cx2t/src/claw/wani/transformation/sca/Parallelize.java
@@ -10,7 +10,9 @@ import claw.tatsu.common.*;
 import claw.tatsu.directive.common.Directive;
 import claw.tatsu.primitive.Body;
 import claw.tatsu.primitive.Field;
+import claw.tatsu.primitive.Function;
 import claw.tatsu.primitive.Module;
+import claw.tatsu.xcodeml.abstraction.AssignStatement;
 import claw.tatsu.xcodeml.abstraction.DimensionDefinition;
 import claw.tatsu.xcodeml.abstraction.NestedDoStatement;
 import claw.tatsu.xcodeml.abstraction.PromotionInfo;
@@ -479,13 +481,12 @@ public class Parallelize extends ClawTransformation {
      * This is for the moment a really naive transformation idea but it is our
      * start point.
      * Use the first over clause to do it. */
-    List<Xnode> assignStatements =
-        _fctDef.body().matchAll(Xcode.F_ASSIGN_STATEMENT);
+    List<AssignStatement> assignStatements =
+        Function.gatherAssignStatements(_fctDef);
 
-    for(Xnode assign : assignStatements) {
-      Xnode lhs = assign.child(Xnode.LHS);
-      String lhsName = (lhs.opcode() == Xcode.VAR) ? lhs.value() :
-          lhs.matchSeq(Xcode.VAR_REF, Xcode.VAR).value();
+    for(AssignStatement assign : assignStatements) {
+      Xnode lhs = assign.getLhs();
+      String lhsName = assign.getLhsName();
       NestedDoStatement loops = null;
       if(lhs.opcode() == Xcode.F_ARRAY_REF &&
           _arrayFieldsInOut.contains(lhsName))

--- a/cx2t/src/claw/wani/transformation/sca/ParallelizeForward.java
+++ b/cx2t/src/claw/wani/transformation/sca/ParallelizeForward.java
@@ -441,7 +441,11 @@ public class ParallelizeForward extends ClawTransformation {
       arg.append(xcodeml.createVar(type, varId, Xscope.LOCAL));
       Xnode arguments = _fctCall.matchSeq(Xcode.ARGUMENTS);
       Xnode hook = arguments.child((i - 1) - argOffset);
-      hook.insertAfter(arg);
+      if(hook != null) {
+        hook.insertAfter(arg);
+      } else {
+        arguments.append(arg);
+      }
     }
 
     // In flatten mode, arguments are demoted if needed.

--- a/cx2t/unittest/claw/tatsu/primitive/ConditionTest.java
+++ b/cx2t/unittest/claw/tatsu/primitive/ConditionTest.java
@@ -42,5 +42,6 @@ public class ConditionTest {
     assertFalse(Condition.dependsOn(null, Collections.singletonList("t")));
     assertFalse(Condition.dependsOn(ifStmt, Collections.singletonList("t")));
     assertTrue(Condition.dependsOn(condition, Collections.singletonList("t")));
+    assertFalse(Condition.dependsOn(condition, Collections.singletonList("k")));
   }
 }

--- a/cx2t/unittest/claw/tatsu/primitive/ConditionTest.java
+++ b/cx2t/unittest/claw/tatsu/primitive/ConditionTest.java
@@ -38,10 +38,10 @@ public class ConditionTest {
     assertNotNull(condition);
 
     assertFalse(Condition.dependsOn(condition,
-        Collections.<String>emptyList()));
-    assertFalse(Condition.dependsOn(null, Collections.singletonList("t")));
-    assertFalse(Condition.dependsOn(ifStmt, Collections.singletonList("t")));
-    assertTrue(Condition.dependsOn(condition, Collections.singletonList("t")));
-    assertFalse(Condition.dependsOn(condition, Collections.singletonList("k")));
+        Collections.<String>emptySet()));
+    assertFalse(Condition.dependsOn(null, Collections.singleton("t")));
+    assertFalse(Condition.dependsOn(ifStmt, Collections.singleton("t")));
+    assertTrue(Condition.dependsOn(condition, Collections.singleton("t")));
+    assertFalse(Condition.dependsOn(condition, Collections.singleton("k")));
   }
 }

--- a/cx2t/unittest/claw/tatsu/primitive/ConditionTest.java
+++ b/cx2t/unittest/claw/tatsu/primitive/ConditionTest.java
@@ -1,0 +1,46 @@
+/*
+ * This file is released under terms of BSD license
+ * See LICENSE file for more information
+ */
+package claw.tatsu.primitive;
+
+import claw.tatsu.xcodeml.xnode.common.Xcode;
+import claw.tatsu.xcodeml.xnode.common.XcodeProgram;
+import claw.tatsu.xcodeml.xnode.common.Xnode;
+import helper.TestConstant;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static junit.framework.TestCase.*;
+
+/**
+ * Test features of the condition primitive class.
+ *
+ * @author clementval
+ */
+public class ConditionTest {
+
+  @Test
+  public void dependsOnTest() {
+    XcodeProgram xcodeml =
+        XcodeProgram.createFromFile(TestConstant.TEST_ASSIGN_STMT);
+    assertNotNull(xcodeml);
+
+    List<Xnode> nodes = xcodeml.matchAll(Xcode.F_IF_STATEMENT);
+    assertEquals(1, nodes.size());
+
+    Xnode ifStmt = nodes.get(0);
+    assertEquals(Xcode.F_IF_STATEMENT, ifStmt.opcode());
+
+    Xnode condition = ifStmt.matchDirectDescendant(Xcode.CONDITION);
+    assertNotNull(condition);
+
+    assertFalse(Condition.dependsOn(condition,
+        Collections.<String>emptyList()));
+    assertFalse(Condition.dependsOn(null, Collections.singletonList("t")));
+    assertFalse(Condition.dependsOn(ifStmt, Collections.singletonList("t")));
+    assertTrue(Condition.dependsOn(condition, Collections.singletonList("t")));
+  }
+}

--- a/cx2t/unittest/claw/tatsu/xcodeml/abstraction/AssignStatementTest.java
+++ b/cx2t/unittest/claw/tatsu/xcodeml/abstraction/AssignStatementTest.java
@@ -25,7 +25,7 @@ import static junit.framework.TestCase.*;
 public class AssignStatementTest {
 
   @Test
-  public void gatherAssignmentTest() {
+  public void gatherAssignmentTest1() {
     XcodeProgram xcodeml =
         XcodeProgram.createFromFile(TestConstant.TEST_ASSIGN_STMT);
     assertNotNull(xcodeml);
@@ -47,5 +47,22 @@ public class AssignStatementTest {
     assertEquals(2, vars.size());
     assertTrue(vars.contains("t"));
     assertTrue(vars.contains("q"));
+  }
+
+  @Test
+  public void gatherAssignmentTest2() {
+    XcodeProgram xcodeml =
+        XcodeProgram.createFromFile(TestConstant.TEST_ASSIGN_STMT2);
+    assertNotNull(xcodeml);
+
+    List<Xnode> nodes = xcodeml.matchAll(Xcode.F_FUNCTION_DEFINITION);
+    assertEquals(1, nodes.size());
+
+    assertEquals(Xcode.F_FUNCTION_DEFINITION, nodes.get(0).opcode());
+    FfunctionDefinition fctDef = new FfunctionDefinition(nodes.get(0));
+
+    List<AssignStatement> assignStatements =
+        Function.gatherAssignStatements(fctDef);
+    assertEquals(4, assignStatements.size());
   }
 }

--- a/cx2t/unittest/claw/tatsu/xcodeml/abstraction/AssignStatementTest.java
+++ b/cx2t/unittest/claw/tatsu/xcodeml/abstraction/AssignStatementTest.java
@@ -13,6 +13,7 @@ import helper.TestConstant;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Set;
 
 import static junit.framework.TestCase.*;
 
@@ -41,5 +42,10 @@ public class AssignStatementTest {
 
     assertTrue(assignStatements.get(0).isChildOf(Xcode.F_IF_STATEMENT));
     assertFalse(assignStatements.get(1).isChildOf(Xcode.F_IF_STATEMENT));
+
+    Set<String> vars = assignStatements.get(0).getVarRefNames();
+    assertEquals(2, vars.size());
+    assertTrue(vars.contains("t"));
+    assertTrue(vars.contains("q"));
   }
 }

--- a/cx2t/unittest/claw/tatsu/xcodeml/abstraction/AssignStatementTest.java
+++ b/cx2t/unittest/claw/tatsu/xcodeml/abstraction/AssignStatementTest.java
@@ -1,0 +1,45 @@
+/*
+ * This file is released under terms of BSD license
+ * See LICENSE file for more information
+ */
+package claw.tatsu.xcodeml.abstraction;
+
+import claw.tatsu.primitive.Function;
+import claw.tatsu.xcodeml.xnode.common.Xcode;
+import claw.tatsu.xcodeml.xnode.common.XcodeProgram;
+import claw.tatsu.xcodeml.xnode.common.Xnode;
+import claw.tatsu.xcodeml.xnode.fortran.FfunctionDefinition;
+import helper.TestConstant;
+import org.junit.Test;
+
+import java.util.List;
+
+import static junit.framework.TestCase.*;
+
+/**
+ * Test features of the AssignStatement class.
+ *
+ * @author clementval
+ */
+public class AssignStatementTest {
+
+  @Test
+  public void gatherAssignmentTest() {
+    XcodeProgram xcodeml =
+        XcodeProgram.createFromFile(TestConstant.TEST_ASSIGN_STMT);
+    assertNotNull(xcodeml);
+
+    List<Xnode> nodes = xcodeml.matchAll(Xcode.F_FUNCTION_DEFINITION);
+    assertEquals(1, nodes.size());
+
+    assertEquals(Xcode.F_FUNCTION_DEFINITION, nodes.get(0).opcode());
+    FfunctionDefinition fctDef = new FfunctionDefinition(nodes.get(0));
+
+    List<AssignStatement> assignStatements =
+        Function.gatherAssignStatements(fctDef);
+    assertEquals(2, assignStatements.size());
+
+    assertTrue(assignStatements.get(0).isChildOf(Xcode.F_IF_STATEMENT));
+    assertFalse(assignStatements.get(1).isChildOf(Xcode.F_IF_STATEMENT));
+  }
+}

--- a/cx2t/unittest/claw/tatsu/xcodeml/xnode/common/XnodeTest.java
+++ b/cx2t/unittest/claw/tatsu/xcodeml/xnode/common/XnodeTest.java
@@ -5,6 +5,7 @@
 package claw.tatsu.xcodeml.xnode.common;
 
 import claw.tatsu.xcodeml.xnode.fortran.FfunctionDefinition;
+import helper.TestConstant;
 import helper.XmlHelper;
 import org.junit.Test;
 
@@ -13,6 +14,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
 import static org.junit.Assert.*;
 
 /**
@@ -275,5 +278,27 @@ public class XnodeTest {
     n1.copyEnhancedInfo(n2);
     assertEquals(1, n2.lineNo());
     assertEquals(filename, n2.filename());
+  }
+
+  @Test
+  public void matchAllAncestorTest() {
+    XcodeProgram xcodeml =
+        XcodeProgram.createFromFile(TestConstant.TEST_ASSIGN_STMT2);
+    assertNotNull(xcodeml);
+
+    List<Xnode> nodes = xcodeml.matchAll(Xcode.F_ASSIGN_STATEMENT);
+    assertEquals(2, nodes.size());
+
+    List<Xnode> matches1 = nodes.get(0).matchAllAncestor(Xcode.F_IF_STATEMENT,
+        Xcode.F_FUNCTION_DEFINITION);
+    List<Xnode> matches2 = nodes.get(0).matchAllAncestor(Xcode.F_IF_STATEMENT);
+    assertEquals(2, matches1.size());
+    assertEquals(2, matches2.size());
+
+    matches1 = nodes.get(1).matchAllAncestor(Xcode.F_IF_STATEMENT,
+        Xcode.F_FUNCTION_DEFINITION);
+    matches2 = nodes.get(1).matchAllAncestor(Xcode.F_IF_STATEMENT);
+    assertEquals(1, matches1.size());
+    assertEquals(1, matches2.size());
   }
 }

--- a/cx2t/unittest/claw/tatsu/xcodeml/xnode/common/XnodeTest.java
+++ b/cx2t/unittest/claw/tatsu/xcodeml/xnode/common/XnodeTest.java
@@ -287,7 +287,7 @@ public class XnodeTest {
     assertNotNull(xcodeml);
 
     List<Xnode> nodes = xcodeml.matchAll(Xcode.F_ASSIGN_STATEMENT);
-    assertEquals(2, nodes.size());
+    assertEquals(4, nodes.size());
 
     List<Xnode> matches1 = nodes.get(0).matchAllAncestor(Xcode.F_IF_STATEMENT,
         Xcode.F_FUNCTION_DEFINITION);
@@ -298,7 +298,13 @@ public class XnodeTest {
     matches1 = nodes.get(1).matchAllAncestor(Xcode.F_IF_STATEMENT,
         Xcode.F_FUNCTION_DEFINITION);
     matches2 = nodes.get(1).matchAllAncestor(Xcode.F_IF_STATEMENT);
-    assertEquals(1, matches1.size());
-    assertEquals(1, matches2.size());
+    assertEquals(2, matches1.size());
+    assertEquals(2, matches2.size());
+
+    matches1 = nodes.get(3).matchAllAncestor(Xcode.F_IF_STATEMENT,
+        Xcode.F_FUNCTION_DEFINITION);
+    matches2 = nodes.get(3).matchAllAncestor(Xcode.F_IF_STATEMENT);
+    assertEquals(0, matches1.size());
+    assertEquals(0, matches2.size());
   }
 }

--- a/cx2t/unittest/data/assignStatement.xml
+++ b/cx2t/unittest/data/assignStatement.xml
@@ -1,0 +1,175 @@
+<XcodeProgram source="mo_column.f90"
+              language="Fortran"
+              time="2018-02-28 11:51:23"
+              compiler-info="XcodeML/Fortran-FrontEnd"
+              version="1.0">
+  <typeTable>
+    <FfunctionType type="F7f812b4086c0" return_type="Fvoid">
+      <params>
+        <name type="I7f812b409b70">nz</name>
+        <name type="A7f812b40af30">q</name>
+        <name type="A7f812b40a550">t</name>
+      </params>
+    </FfunctionType>
+    <FbasicType type="I7f812b409b70" intent="in" ref="Fint"/>
+    <FbasicType type="R7f812b40ae10" intent="inout" ref="Freal"/>
+    <FbasicType type="A7f812b40af30" intent="inout" ref="R7f812b40ae10">
+      <indexRange is_assumed_shape="true">
+      </indexRange>
+    </FbasicType>
+    <FbasicType type="R7f812b40a430" intent="inout" ref="Freal"/>
+    <FbasicType type="A7f812b40a550" intent="inout" ref="R7f812b40a430">
+      <indexRange is_assumed_shape="true">
+      </indexRange>
+    </FbasicType>
+  </typeTable>
+  <globalSymbols>
+    <id sclass="ffunc">
+      <name>mo_column</name>
+    </id>
+  </globalSymbols>
+  <globalDeclarations>
+    <FmoduleDefinition name="mo_column" lineno="6" file="mo_column.f90">
+      <symbols>
+        <id type="F7f812b4086c0" sclass="ffunc">
+          <name>compute_column</name>
+        </id>
+      </symbols>
+      <declarations>
+      </declarations>
+      <FcontainsStatement lineno="8" file="mo_column.f90">
+        <FfunctionDefinition lineno="10" file="mo_column.f90">
+          <name type="F7f812b4086c0">compute_column</name>
+          <symbols>
+            <id type="F7f812b4086c0" sclass="ffunc">
+              <name>compute_column</name>
+            </id>
+            <id type="I7f812b409b70" sclass="fparam">
+              <name>nz</name>
+            </id>
+            <id type="A7f812b40af30" sclass="fparam">
+              <name>q</name>
+            </id>
+            <id type="A7f812b40a550" sclass="fparam">
+              <name>t</name>
+            </id>
+            <id type="Fint" sclass="flocal">
+              <name>k</name>
+            </id>
+          </symbols>
+          <declarations>
+            <varDecl lineno="10" file="mo_column.f90">
+              <name type="F7f812b4086c0">compute_column</name>
+            </varDecl>
+            <varDecl lineno="13" file="mo_column.f90">
+              <name type="I7f812b409b70">nz</name>
+            </varDecl>
+            <varDecl lineno="14" file="mo_column.f90">
+              <name type="A7f812b40a550">t</name>
+            </varDecl>
+            <varDecl lineno="15" file="mo_column.f90">
+              <name type="A7f812b40af30">q</name>
+            </varDecl>
+            <varDecl lineno="16" file="mo_column.f90">
+              <name type="Fint">k</name>
+            </varDecl>
+          </declarations>
+          <body>
+            <FpragmaStatement lineno="24" file="mo_column.f90">claw define dimension proma(1:nproma) claw parallelize</FpragmaStatement>
+            <FdoStatement lineno="27" file="mo_column.f90">
+              <Var type="Fint" scope="local">k</Var>
+              <indexRange>
+                <lowerBound>
+                  <FintConstant type="Fint">1</FintConstant>
+                </lowerBound>
+                <upperBound>
+                  <Var type="I7f812b409b70" scope="local">nz</Var>
+                </upperBound>
+                <step>
+                  <FintConstant type="Fint">1</FintConstant>
+                </step>
+              </indexRange>
+              <body>
+                <FifStatement lineno="28" file="mo_column.f90">
+                  <condition>
+                    <logGTExpr type="Flogical">
+                      <FarrayRef type="R7f812b40a430">
+                        <varRef type="A7f812b40a550">
+                          <Var type="A7f812b40a550" scope="local">t</Var>
+                        </varRef>
+                        <arrayIndex>
+                          <Var type="Fint" scope="local">k</Var>
+                        </arrayIndex>
+                      </FarrayRef>
+                      <FrealConstant type="Freal">0.</FrealConstant>
+                    </logGTExpr>
+                  </condition>
+                  <then>
+                    <body>
+                      <FassignStatement lineno="29" file="mo_column.f90">
+                        <FarrayRef type="R7f812b40ae10">
+                          <varRef type="A7f812b40af30">
+                            <Var type="A7f812b40af30" scope="local">q</Var>
+                          </varRef>
+                          <arrayIndex>
+                            <Var type="Fint" scope="local">k</Var>
+                          </arrayIndex>
+                        </FarrayRef>
+                        <divExpr type="R7f812b40ae10">
+                          <FarrayRef type="R7f812b40ae10">
+                            <varRef type="A7f812b40af30">
+                              <Var type="A7f812b40af30" scope="local">q</Var>
+                            </varRef>
+                            <arrayIndex>
+                              <Var type="Fint" scope="local">k</Var>
+                            </arrayIndex>
+                          </FarrayRef>
+                          <FarrayRef type="R7f812b40a430">
+                            <varRef type="A7f812b40a550">
+                              <Var type="A7f812b40a550" scope="local">t</Var>
+                            </varRef>
+                            <arrayIndex>
+                              <Var type="Fint" scope="local">k</Var>
+                            </arrayIndex>
+                          </FarrayRef>
+                        </divExpr>
+                      </FassignStatement>
+                    </body>
+                  </then>
+                </FifStatement>
+                <FassignStatement lineno="29" file="mo_column.f90">
+                  <FarrayRef type="R7f812b40ae10">
+                    <varRef type="A7f812b40af30">
+                      <Var type="A7f812b40af30" scope="local">q</Var>
+                    </varRef>
+                    <arrayIndex>
+                      <Var type="Fint" scope="local">k</Var>
+                    </arrayIndex>
+                  </FarrayRef>
+                  <divExpr type="R7f812b40ae10">
+                    <FarrayRef type="R7f812b40ae10">
+                      <varRef type="A7f812b40af30">
+                        <Var type="A7f812b40af30" scope="local">q</Var>
+                      </varRef>
+                      <arrayIndex>
+                        <Var type="Fint" scope="local">k</Var>
+                      </arrayIndex>
+                    </FarrayRef>
+                    <FarrayRef type="R7f812b40a430">
+                      <varRef type="A7f812b40a550">
+                        <Var type="A7f812b40a550" scope="local">t</Var>
+                      </varRef>
+                      <arrayIndex>
+                        <Var type="Fint" scope="local">k</Var>
+                      </arrayIndex>
+                    </FarrayRef>
+                  </divExpr>
+                </FassignStatement>
+              </body>
+            </FdoStatement>
+          </body>
+        </FfunctionDefinition>
+      </FcontainsStatement>
+    </FmoduleDefinition>
+  </globalDeclarations>
+</XcodeProgram>

--- a/cx2t/unittest/data/assignStatement2.xml
+++ b/cx2t/unittest/data/assignStatement2.xml
@@ -1,0 +1,191 @@
+<XcodeProgram source="mo_column.f90"
+              language="Fortran"
+              time="2018-02-28 14:15:38"
+              compiler-info="XcodeML/Fortran-FrontEnd"
+              version="1.0">
+  <typeTable>
+    <FfunctionType type="F7fcccad060e0" return_type="Fvoid">
+      <params>
+        <name type="I7fcccad07590">nz</name>
+        <name type="A7fcccad08950">q</name>
+        <name type="A7fcccad07f70">t</name>
+      </params>
+    </FfunctionType>
+    <FbasicType type="I7fcccad07590" intent="in" ref="Fint"/>
+    <FbasicType type="R7fcccad08830" intent="inout" ref="Freal"/>
+    <FbasicType type="A7fcccad08950" intent="inout" ref="R7fcccad08830">
+      <indexRange is_assumed_shape="true">
+      </indexRange>
+    </FbasicType>
+    <FbasicType type="R7fcccad07e50" intent="inout" ref="Freal"/>
+    <FbasicType type="A7fcccad07f70" intent="inout" ref="R7fcccad07e50">
+      <indexRange is_assumed_shape="true">
+      </indexRange>
+    </FbasicType>
+  </typeTable>
+  <globalSymbols>
+    <id sclass="ffunc">
+      <name>mo_column</name>
+    </id>
+  </globalSymbols>
+  <globalDeclarations>
+    <FmoduleDefinition name="mo_column" lineno="6" file="mo_column.f90">
+      <symbols>
+        <id type="F7fcccad060e0" sclass="ffunc">
+          <name>compute_column</name>
+        </id>
+      </symbols>
+      <declarations>
+      </declarations>
+      <FcontainsStatement lineno="8" file="mo_column.f90">
+        <FfunctionDefinition lineno="10" file="mo_column.f90">
+          <name type="F7fcccad060e0">compute_column</name>
+          <symbols>
+            <id type="F7fcccad060e0" sclass="ffunc">
+              <name>compute_column</name>
+            </id>
+            <id type="I7fcccad07590" sclass="fparam">
+              <name>nz</name>
+            </id>
+            <id type="A7fcccad08950" sclass="fparam">
+              <name>q</name>
+            </id>
+            <id type="A7fcccad07f70" sclass="fparam">
+              <name>t</name>
+            </id>
+            <id type="Fint" sclass="flocal">
+              <name>k</name>
+            </id>
+          </symbols>
+          <declarations>
+            <varDecl lineno="10" file="mo_column.f90">
+              <name type="F7fcccad060e0">compute_column</name>
+            </varDecl>
+            <varDecl lineno="13" file="mo_column.f90">
+              <name type="I7fcccad07590">nz</name>
+            </varDecl>
+            <varDecl lineno="14" file="mo_column.f90">
+              <name type="A7fcccad07f70">t</name>
+            </varDecl>
+            <varDecl lineno="15" file="mo_column.f90">
+              <name type="A7fcccad08950">q</name>
+            </varDecl>
+            <varDecl lineno="16" file="mo_column.f90">
+              <name type="Fint">k</name>
+            </varDecl>
+          </declarations>
+          <body>
+            <FpragmaStatement lineno="24" file="mo_column.f90">claw define dimension proma(1:nproma) claw parallelize</FpragmaStatement>
+            <FdoStatement lineno="27" file="mo_column.f90">
+              <Var type="Fint" scope="local">k</Var>
+              <indexRange>
+                <lowerBound>
+                  <FintConstant type="Fint">1</FintConstant>
+                </lowerBound>
+                <upperBound>
+                  <Var type="I7fcccad07590" scope="local">nz</Var>
+                </upperBound>
+                <step>
+                  <FintConstant type="Fint">1</FintConstant>
+                </step>
+              </indexRange>
+              <body>
+                <FifStatement lineno="28" file="mo_column.f90">
+                  <condition>
+                    <logGTExpr type="Flogical">
+                      <FarrayRef type="R7fcccad07e50">
+                        <varRef type="A7fcccad07f70">
+                          <Var type="A7fcccad07f70" scope="local">t</Var>
+                        </varRef>
+                        <arrayIndex>
+                          <Var type="Fint" scope="local">k</Var>
+                        </arrayIndex>
+                      </FarrayRef>
+                      <FrealConstant type="Freal">0.</FrealConstant>
+                    </logGTExpr>
+                  </condition>
+                  <then>
+                    <body>
+                      <FifStatement lineno="29" file="mo_column.f90">
+                        <condition>
+                          <logLTExpr type="Flogical">
+                            <Var type="Fint" scope="local">k</Var>
+                            <FintConstant type="Fint">10</FintConstant>
+                          </logLTExpr>
+                        </condition>
+                        <then>
+                          <body>
+                            <FassignStatement lineno="30" file="mo_column.f90">
+                              <FarrayRef type="R7fcccad08830">
+                                <varRef type="A7fcccad08950">
+                                  <Var type="A7fcccad08950" scope="local">q</Var>
+                                </varRef>
+                                <arrayIndex>
+                                  <Var type="Fint" scope="local">k</Var>
+                                </arrayIndex>
+                              </FarrayRef>
+                              <divExpr type="R7fcccad08830">
+                                <FarrayRef type="R7fcccad08830">
+                                  <varRef type="A7fcccad08950">
+                                    <Var type="A7fcccad08950" scope="local">q</Var>
+                                  </varRef>
+                                  <arrayIndex>
+                                    <Var type="Fint" scope="local">k</Var>
+                                  </arrayIndex>
+                                </FarrayRef>
+                                <FarrayRef type="R7fcccad07e50">
+                                  <varRef type="A7fcccad07f70">
+                                    <Var type="A7fcccad07f70" scope="local">t</Var>
+                                  </varRef>
+                                  <arrayIndex>
+                                    <Var type="Fint" scope="local">k</Var>
+                                  </arrayIndex>
+                                </FarrayRef>
+                              </divExpr>
+                            </FassignStatement>
+                          </body>
+                        </then>
+                      </FifStatement>
+                    </body>
+                  </then>
+                  <else>
+                    <body>
+                      <FassignStatement lineno="33" file="mo_column.f90">
+                        <FarrayRef type="R7fcccad08830">
+                          <varRef type="A7fcccad08950">
+                            <Var type="A7fcccad08950" scope="local">q</Var>
+                          </varRef>
+                          <arrayIndex>
+                            <Var type="Fint" scope="local">k</Var>
+                          </arrayIndex>
+                        </FarrayRef>
+                        <mulExpr type="R7fcccad08830">
+                          <FarrayRef type="R7fcccad08830">
+                            <varRef type="A7fcccad08950">
+                              <Var type="A7fcccad08950" scope="local">q</Var>
+                            </varRef>
+                            <arrayIndex>
+                              <Var type="Fint" scope="local">k</Var>
+                            </arrayIndex>
+                          </FarrayRef>
+                          <FarrayRef type="R7fcccad08830">
+                            <varRef type="A7fcccad08950">
+                              <Var type="A7fcccad08950" scope="local">q</Var>
+                            </varRef>
+                            <arrayIndex>
+                              <Var type="Fint" scope="local">k</Var>
+                            </arrayIndex>
+                          </FarrayRef>
+                        </mulExpr>
+                      </FassignStatement>
+                    </body>
+                  </else>
+                </FifStatement>
+              </body>
+            </FdoStatement>
+          </body>
+        </FfunctionDefinition>
+      </FcontainsStatement>
+    </FmoduleDefinition>
+  </globalDeclarations>
+</XcodeProgram>

--- a/cx2t/unittest/data/assignStatement2.xml
+++ b/cx2t/unittest/data/assignStatement2.xml
@@ -1,24 +1,30 @@
 <XcodeProgram source="mo_column.f90"
               language="Fortran"
-              time="2018-02-28 14:15:38"
+              time="2018-02-28 14:57:50"
               compiler-info="XcodeML/Fortran-FrontEnd"
               version="1.0">
   <typeTable>
-    <FfunctionType type="F7fcccad060e0" return_type="Fvoid">
+    <FfunctionType type="F7ff1cfe015c0" return_type="Fvoid">
       <params>
-        <name type="I7fcccad07590">nz</name>
-        <name type="A7fcccad08950">q</name>
-        <name type="A7fcccad07f70">t</name>
+        <name type="I7ff1cfe02d60">nz</name>
+        <name type="A7ff1cfe04120">q</name>
+        <name type="A7ff1cfe03740">t</name>
+        <name type="A7ff1cfe04b00">z</name>
       </params>
     </FfunctionType>
-    <FbasicType type="I7fcccad07590" intent="in" ref="Fint"/>
-    <FbasicType type="R7fcccad08830" intent="inout" ref="Freal"/>
-    <FbasicType type="A7fcccad08950" intent="inout" ref="R7fcccad08830">
+    <FbasicType type="I7ff1cfe02d60" intent="in" ref="Fint"/>
+    <FbasicType type="R7ff1cfe04000" intent="inout" ref="Freal"/>
+    <FbasicType type="A7ff1cfe04120" intent="inout" ref="R7ff1cfe04000">
       <indexRange is_assumed_shape="true">
       </indexRange>
     </FbasicType>
-    <FbasicType type="R7fcccad07e50" intent="inout" ref="Freal"/>
-    <FbasicType type="A7fcccad07f70" intent="inout" ref="R7fcccad07e50">
+    <FbasicType type="R7ff1cfe03620" intent="inout" ref="Freal"/>
+    <FbasicType type="A7ff1cfe03740" intent="inout" ref="R7ff1cfe03620">
+      <indexRange is_assumed_shape="true">
+      </indexRange>
+    </FbasicType>
+    <FbasicType type="R7ff1cfe049e0" intent="inout" ref="Freal"/>
+    <FbasicType type="A7ff1cfe04b00" intent="inout" ref="R7ff1cfe049e0">
       <indexRange is_assumed_shape="true">
       </indexRange>
     </FbasicType>
@@ -31,7 +37,7 @@
   <globalDeclarations>
     <FmoduleDefinition name="mo_column" lineno="6" file="mo_column.f90">
       <symbols>
-        <id type="F7fcccad060e0" sclass="ffunc">
+        <id type="F7ff1cfe015c0" sclass="ffunc">
           <name>compute_column</name>
         </id>
       </symbols>
@@ -39,19 +45,25 @@
       </declarations>
       <FcontainsStatement lineno="8" file="mo_column.f90">
         <FfunctionDefinition lineno="10" file="mo_column.f90">
-          <name type="F7fcccad060e0">compute_column</name>
+          <name type="F7ff1cfe015c0">compute_column</name>
           <symbols>
-            <id type="F7fcccad060e0" sclass="ffunc">
+            <id type="F7ff1cfe015c0" sclass="ffunc">
               <name>compute_column</name>
             </id>
-            <id type="I7fcccad07590" sclass="fparam">
+            <id type="I7ff1cfe02d60" sclass="fparam">
               <name>nz</name>
             </id>
-            <id type="A7fcccad08950" sclass="fparam">
+            <id type="A7ff1cfe04120" sclass="fparam">
               <name>q</name>
             </id>
-            <id type="A7fcccad07f70" sclass="fparam">
+            <id type="A7ff1cfe03740" sclass="fparam">
               <name>t</name>
+            </id>
+            <id type="A7ff1cfe04b00" sclass="fparam">
+              <name>z</name>
+            </id>
+            <id type="Freal" sclass="flocal">
+              <name>tmp</name>
             </id>
             <id type="Fint" sclass="flocal">
               <name>k</name>
@@ -59,43 +71,49 @@
           </symbols>
           <declarations>
             <varDecl lineno="10" file="mo_column.f90">
-              <name type="F7fcccad060e0">compute_column</name>
+              <name type="F7ff1cfe015c0">compute_column</name>
             </varDecl>
             <varDecl lineno="13" file="mo_column.f90">
-              <name type="I7fcccad07590">nz</name>
+              <name type="I7ff1cfe02d60">nz</name>
             </varDecl>
             <varDecl lineno="14" file="mo_column.f90">
-              <name type="A7fcccad07f70">t</name>
+              <name type="A7ff1cfe03740">t</name>
             </varDecl>
             <varDecl lineno="15" file="mo_column.f90">
-              <name type="A7fcccad08950">q</name>
+              <name type="A7ff1cfe04120">q</name>
             </varDecl>
             <varDecl lineno="16" file="mo_column.f90">
+              <name type="A7ff1cfe04b00">z</name>
+            </varDecl>
+            <varDecl lineno="17" file="mo_column.f90">
+              <name type="Freal">tmp</name>
+            </varDecl>
+            <varDecl lineno="18" file="mo_column.f90">
               <name type="Fint">k</name>
             </varDecl>
           </declarations>
           <body>
-            <FpragmaStatement lineno="24" file="mo_column.f90">claw define dimension proma(1:nproma) claw parallelize</FpragmaStatement>
-            <FdoStatement lineno="27" file="mo_column.f90">
+            <FpragmaStatement lineno="26" file="mo_column.f90">claw define dimension proma(1:nproma) claw parallelize</FpragmaStatement>
+            <FdoStatement lineno="29" file="mo_column.f90">
               <Var type="Fint" scope="local">k</Var>
               <indexRange>
                 <lowerBound>
                   <FintConstant type="Fint">1</FintConstant>
                 </lowerBound>
                 <upperBound>
-                  <Var type="I7fcccad07590" scope="local">nz</Var>
+                  <Var type="I7ff1cfe02d60" scope="local">nz</Var>
                 </upperBound>
                 <step>
                   <FintConstant type="Fint">1</FintConstant>
                 </step>
               </indexRange>
               <body>
-                <FifStatement lineno="28" file="mo_column.f90">
+                <FifStatement lineno="30" file="mo_column.f90">
                   <condition>
                     <logGTExpr type="Flogical">
-                      <FarrayRef type="R7fcccad07e50">
-                        <varRef type="A7fcccad07f70">
-                          <Var type="A7fcccad07f70" scope="local">t</Var>
+                      <FarrayRef type="R7ff1cfe03620">
+                        <varRef type="A7ff1cfe03740">
+                          <Var type="A7ff1cfe03740" scope="local">t</Var>
                         </varRef>
                         <arrayIndex>
                           <Var type="Fint" scope="local">k</Var>
@@ -106,7 +124,7 @@
                   </condition>
                   <then>
                     <body>
-                      <FifStatement lineno="29" file="mo_column.f90">
+                      <FifStatement lineno="31" file="mo_column.f90">
                         <condition>
                           <logLTExpr type="Flogical">
                             <Var type="Fint" scope="local">k</Var>
@@ -115,27 +133,41 @@
                         </condition>
                         <then>
                           <body>
-                            <FassignStatement lineno="30" file="mo_column.f90">
-                              <FarrayRef type="R7fcccad08830">
-                                <varRef type="A7fcccad08950">
-                                  <Var type="A7fcccad08950" scope="local">q</Var>
-                                </varRef>
-                                <arrayIndex>
-                                  <Var type="Fint" scope="local">k</Var>
-                                </arrayIndex>
-                              </FarrayRef>
-                              <divExpr type="R7fcccad08830">
-                                <FarrayRef type="R7fcccad08830">
-                                  <varRef type="A7fcccad08950">
-                                    <Var type="A7fcccad08950" scope="local">q</Var>
+                            <FassignStatement lineno="32" file="mo_column.f90">
+                              <Var type="Freal" scope="local">tmp</Var>
+                              <plusExpr type="Freal">
+                                <Var type="Freal" scope="local">tmp</Var>
+                                <FarrayRef type="R7ff1cfe04000">
+                                  <varRef type="A7ff1cfe04120">
+                                    <Var type="A7ff1cfe04120" scope="local">q</Var>
                                   </varRef>
                                   <arrayIndex>
                                     <Var type="Fint" scope="local">k</Var>
                                   </arrayIndex>
                                 </FarrayRef>
-                                <FarrayRef type="R7fcccad07e50">
-                                  <varRef type="A7fcccad07f70">
-                                    <Var type="A7fcccad07f70" scope="local">t</Var>
+                              </plusExpr>
+                            </FassignStatement>
+                            <FassignStatement lineno="33" file="mo_column.f90">
+                              <FarrayRef type="R7ff1cfe04000">
+                                <varRef type="A7ff1cfe04120">
+                                  <Var type="A7ff1cfe04120" scope="local">q</Var>
+                                </varRef>
+                                <arrayIndex>
+                                  <Var type="Fint" scope="local">k</Var>
+                                </arrayIndex>
+                              </FarrayRef>
+                              <divExpr type="R7ff1cfe04000">
+                                <FarrayRef type="R7ff1cfe04000">
+                                  <varRef type="A7ff1cfe04120">
+                                    <Var type="A7ff1cfe04120" scope="local">q</Var>
+                                  </varRef>
+                                  <arrayIndex>
+                                    <Var type="Fint" scope="local">k</Var>
+                                  </arrayIndex>
+                                </FarrayRef>
+                                <FarrayRef type="R7ff1cfe03620">
+                                  <varRef type="A7ff1cfe03740">
+                                    <Var type="A7ff1cfe03740" scope="local">t</Var>
                                   </varRef>
                                   <arrayIndex>
                                     <Var type="Fint" scope="local">k</Var>
@@ -150,27 +182,27 @@
                   </then>
                   <else>
                     <body>
-                      <FassignStatement lineno="33" file="mo_column.f90">
-                        <FarrayRef type="R7fcccad08830">
-                          <varRef type="A7fcccad08950">
-                            <Var type="A7fcccad08950" scope="local">q</Var>
+                      <FassignStatement lineno="36" file="mo_column.f90">
+                        <FarrayRef type="R7ff1cfe04000">
+                          <varRef type="A7ff1cfe04120">
+                            <Var type="A7ff1cfe04120" scope="local">q</Var>
                           </varRef>
                           <arrayIndex>
                             <Var type="Fint" scope="local">k</Var>
                           </arrayIndex>
                         </FarrayRef>
-                        <mulExpr type="R7fcccad08830">
-                          <FarrayRef type="R7fcccad08830">
-                            <varRef type="A7fcccad08950">
-                              <Var type="A7fcccad08950" scope="local">q</Var>
+                        <mulExpr type="R7ff1cfe04000">
+                          <FarrayRef type="R7ff1cfe04000">
+                            <varRef type="A7ff1cfe04120">
+                              <Var type="A7ff1cfe04120" scope="local">q</Var>
                             </varRef>
                             <arrayIndex>
                               <Var type="Fint" scope="local">k</Var>
                             </arrayIndex>
                           </FarrayRef>
-                          <FarrayRef type="R7fcccad08830">
-                            <varRef type="A7fcccad08950">
-                              <Var type="A7fcccad08950" scope="local">q</Var>
+                          <FarrayRef type="R7ff1cfe049e0">
+                            <varRef type="A7ff1cfe04b00">
+                              <Var type="A7ff1cfe04b00" scope="local">z</Var>
                             </varRef>
                             <arrayIndex>
                               <Var type="Fint" scope="local">k</Var>
@@ -181,6 +213,27 @@
                     </body>
                   </else>
                 </FifStatement>
+                <FassignStatement lineno="38" file="mo_column.f90">
+                  <FarrayRef type="R7ff1cfe049e0">
+                    <varRef type="A7ff1cfe04b00">
+                      <Var type="A7ff1cfe04b00" scope="local">z</Var>
+                    </varRef>
+                    <arrayIndex>
+                      <Var type="Fint" scope="local">k</Var>
+                    </arrayIndex>
+                  </FarrayRef>
+                  <mulExpr type="R7ff1cfe049e0">
+                    <FarrayRef type="R7ff1cfe049e0">
+                      <varRef type="A7ff1cfe04b00">
+                        <Var type="A7ff1cfe04b00" scope="local">z</Var>
+                      </varRef>
+                      <arrayIndex>
+                        <Var type="Fint" scope="local">k</Var>
+                      </arrayIndex>
+                    </FarrayRef>
+                    <Var type="Freal" scope="local">tmp</Var>
+                  </mulExpr>
+                </FassignStatement>
               </body>
             </FdoStatement>
           </body>

--- a/cx2t/unittest/helper/TestConstant.java.in
+++ b/cx2t/unittest/helper/TestConstant.java.in
@@ -29,5 +29,7 @@ public class TestConstant {
     "@CMAKE_CURRENT_SOURCE_DIR@/data/promotion.xml";
   public static final String TEST_ASSIGN_STMT =
     "@CMAKE_CURRENT_SOURCE_DIR@/data/assignStatement.xml";
+  public static final String TEST_ASSIGN_STMT2 =
+    "@CMAKE_CURRENT_SOURCE_DIR@/data/assignStatement2.xml";
   public static final String TEST_CONFIG = "@CMAKE_SOURCE_DIR@/driver/etc/";
 }

--- a/cx2t/unittest/helper/TestConstant.java.in
+++ b/cx2t/unittest/helper/TestConstant.java.in
@@ -27,5 +27,7 @@ public class TestConstant {
     "@CMAKE_CURRENT_SOURCE_DIR@/data/arguments.xml";
   public static final String TEST_PROMOTION =
     "@CMAKE_CURRENT_SOURCE_DIR@/data/promotion.xml";
+  public static final String TEST_ASSIGN_STMT =
+    "@CMAKE_CURRENT_SOURCE_DIR@/data/assignStatement.xml";
   public static final String TEST_CONFIG = "@CMAKE_SOURCE_DIR@/driver/etc/";
 }

--- a/driver/bin/clawfc.in
+++ b/driver/bin/clawfc.in
@@ -177,7 +177,7 @@ for input_file in "${f_files[@]}"; do
     if [[ "${num_directives}" == "0" ]] &&
       [[ "${num_omp_compile_guard}" == "0" ]] &&
       [[ "${num_acc_compile_guard}" == "0" ]]; then
-      claw::warning "${input_file}" "-" "file does not contains \$claw. Skip..."
+      claw::warning "${input_file}" "-" "-" "file does not contains \$claw. Skip..."
       if [[ "${output_dir}" != "" ]]; then
         cp "${input_file}" "${output_dir}"/"${input_file}"
       else

--- a/driver/bin/clawfc.in
+++ b/driver/bin/clawfc.in
@@ -224,7 +224,7 @@ for input_file in "${f_files_transformation[@]}"; do
       # Call to the preprocessor
       # shellcheck disable=SC2086,SC2068
       ${OMNI_FPP_CMD} ${include_opt[@]} ${pp_add_opt[@]} \
-        ${OMNI_FPP_OPT} ${other_args[@]} "${file_pp}" >"${file_pp2}"
+        ${OMNI_FPP_OPT} ${other_args[@]} "${file_pp}" > "${file_pp2}"
 
       mv "${file_pp2}" "${file_pp}"
     else

--- a/driver/libexec/claw_f_lib.sh.in
+++ b/driver/libexec/claw_f_lib.sh.in
@@ -508,7 +508,7 @@ function claw::process_dependencies() {
         [[ "${module_name}" != "ieee_features" ]] &&
         [[ "${module_name}" != "ieee_exceptions" ]] &&
         [[ "${module_name}" != "ieee_arithmetic" ]]; then
-        claw::warning "$2" "-" \
+        claw::warning "$2" "-" "-" \
           "only module file found for ${module_name}. Might be out-of-date..."
       fi
       continue
@@ -644,7 +644,7 @@ function claw::applyPreprocessorPass() {
     while IFS= read -r line; do
       if [[ ${line} =~ \\$ ]] && [[ ${line} =~ .*!.* ]]; then
         echo "${line//\\/}" >>"$2"
-        claw::warning "${input_file}" "${line_no}" \
+        claw::warning "${input_file}" "${line_no}" "-" \
           "'\' symbol at the end of a comment line. Possible preprocessing error."
       else
         echo "${line}" >>"$2"

--- a/test/claw/abstraction/CMakeLists.txt
+++ b/test/claw/abstraction/CMakeLists.txt
@@ -36,7 +36,7 @@
 # abstraction33: claw nodep on k loop (openacc_collapse = true)
 # abstraction34: (#355) CPU specific categorization for assign statement
 
-foreach(loop_var RANGE 1 34)
+foreach(loop_var RANGE 1 35)
   if(NOT ${loop_var} EQUAL 30)
     set(CLAW_FLAGS_TARGET_CPU_abstraction${loop_var} --directive=none)
   endif()

--- a/test/claw/abstraction/CMakeLists.txt
+++ b/test/claw/abstraction/CMakeLists.txt
@@ -34,8 +34,9 @@
 # abstraction31: parallelize forward with type%member slicing
 # abstraction32: parallel region start/end after/before unsupported + update/create
 # abstraction33: claw nodep on k loop (openacc_collapse = true)
+# abstraction34: (#355) CPU specific categorization for assign statement
 
-foreach(loop_var RANGE 1 33)
+foreach(loop_var RANGE 1 34)
   if(NOT ${loop_var} EQUAL 30)
     set(CLAW_FLAGS_TARGET_CPU_abstraction${loop_var} --directive=none)
   endif()
@@ -51,6 +52,7 @@ claw_add_advanced_test_set(
   EXCLUDE abstraction30
 )
 
+# Specific "fail" test to check correct failure
 claw_add_failure_test(
   NAME claw-sca-abstraction30
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/abstraction30

--- a/test/claw/abstraction/abstraction34/main.f90
+++ b/test/claw/abstraction/abstraction34/main.f90
@@ -1,0 +1,27 @@
+!
+! This file is released under terms of BSD license
+! See LICENSE file for more information
+!
+
+PROGRAM test_column_conditional
+  USE mo_column, ONLY: compute_column
+  REAL, DIMENSION(5,10) :: q, t  ! Fields as declared in the whole model
+  INTEGER :: nproma, nz           ! Size of array fields
+  INTEGER :: p                    ! Loop index
+
+  nproma = 5
+  nz = 10
+
+  DO p = 1, nproma
+    q(p, 1:nz) = 6.0
+    t(p, 1:6) = 2.0
+    t(p, 6:nz) = 0.0
+  END DO
+
+  !$claw parallelize forward
+  DO p = 1, nproma
+    CALL compute_column(nz, q(p,:), t(p,:))
+  END DO
+
+  PRINT*, (q(1, i), i=1,10)
+END PROGRAM test_column_conditional

--- a/test/claw/abstraction/abstraction34/mo_column.f90
+++ b/test/claw/abstraction/abstraction34/mo_column.f90
@@ -1,0 +1,33 @@
+!
+! This file is released under terms of BSD license
+! See LICENSE file for more information
+!
+
+MODULE mo_column
+  IMPLICIT NONE
+CONTAINS
+  ! Compute only one column
+  SUBROUTINE compute_column(nz, q, t)
+    IMPLICIT NONE
+
+    INTEGER, INTENT(IN)   :: nz   ! Size of the array field
+    REAL, INTENT(INOUT)   :: t(:) ! Field declared as one column only
+    REAL, INTENT(INOUT)   :: q(:) ! Field declared as one column only
+    INTEGER :: k                  ! Loop index
+
+    ! CLAW definition
+
+    ! Define one dimension that will be added to the variables defined in the
+    ! data clause.
+    ! Apply the parallelization transformation on this subroutine.
+
+    !$claw define dimension proma(1:nproma) &
+    !$claw parallelize
+
+    DO k = 1, nz
+      IF (t(k) > 0.) THEN
+        q(k) = q(k) / t(k)
+      END IF
+    END DO
+  END SUBROUTINE compute_column
+END MODULE mo_column

--- a/test/claw/abstraction/abstraction34/reference_cpu.f90
+++ b/test/claw/abstraction/abstraction34/reference_cpu.f90
@@ -1,0 +1,23 @@
+MODULE mo_column
+
+CONTAINS
+ SUBROUTINE compute_column ( nz , q , t , nproma )
+
+  INTEGER , INTENT(IN) :: nz
+  REAL , INTENT(INOUT) :: t ( : , : )
+  REAL , INTENT(INOUT) :: q ( : , : )
+  INTEGER , INTENT(IN) :: nproma
+  INTEGER :: k
+  INTEGER :: proma
+
+  DO k = 1 , nz , 1
+   DO proma = 1 , nproma , 1
+    IF ( t ( proma , k ) > 0. ) THEN
+     q ( proma , k ) = q ( proma , k ) / t ( proma , k )
+    END IF
+   END DO
+  END DO
+ END SUBROUTINE compute_column
+
+END MODULE mo_column
+

--- a/test/claw/abstraction/abstraction34/reference_gpu.f90
+++ b/test/claw/abstraction/abstraction34/reference_gpu.f90
@@ -1,0 +1,29 @@
+MODULE mo_column
+
+CONTAINS
+ SUBROUTINE compute_column ( nz , q , t , nproma )
+
+  INTEGER , INTENT(IN) :: nz
+  REAL , INTENT(INOUT) :: t ( : , : )
+  REAL , INTENT(INOUT) :: q ( : , : )
+  INTEGER , INTENT(IN) :: nproma
+  INTEGER :: k
+  INTEGER :: proma
+
+!$acc loop seq
+!$acc data present(t,q)
+!$acc parallel
+!$acc loop gang vector
+  DO proma = 1 , nproma , 1
+   DO k = 1 , nz , 1
+    IF ( t ( proma , k ) > 0. ) THEN
+     q ( proma , k ) = q ( proma , k ) / t ( proma , k )
+    END IF
+   END DO
+  END DO
+!$acc end parallel
+!$acc end data
+ END SUBROUTINE compute_column
+
+END MODULE mo_column
+

--- a/test/claw/abstraction/abstraction34/reference_main_cpu.f90
+++ b/test/claw/abstraction/abstraction34/reference_main_cpu.f90
@@ -1,0 +1,20 @@
+PROGRAM test_column_conditional
+ USE mo_column , ONLY: compute_column
+ REAL :: q ( 1 : 5 , 1 : 10 )
+ REAL :: t ( 1 : 5 , 1 : 10 )
+ INTEGER :: nproma
+ INTEGER :: nz
+ INTEGER :: p
+ INTEGER :: i
+
+ nproma = 5
+ nz = 10
+ DO p = 1 , nproma , 1
+  q ( p , 1 : nz ) = 6.0
+  t ( p , 1 : 6 ) = 2.0
+  t ( p , 6 : nz ) = 0.0
+ END DO
+ CALL compute_column ( nz , q ( : , : ) , t ( : , : ) , nproma = nproma )
+ PRINT * , ( q ( 1 , i ) , i = 1 , 10 , 1 )
+END PROGRAM test_column_conditional
+

--- a/test/claw/abstraction/abstraction34/reference_main_gpu.f90
+++ b/test/claw/abstraction/abstraction34/reference_main_gpu.f90
@@ -1,0 +1,20 @@
+PROGRAM test_column_conditional
+ USE mo_column , ONLY: compute_column
+ REAL :: q ( 1 : 5 , 1 : 10 )
+ REAL :: t ( 1 : 5 , 1 : 10 )
+ INTEGER :: nproma
+ INTEGER :: nz
+ INTEGER :: p
+ INTEGER :: i
+
+ nproma = 5
+ nz = 10
+ DO p = 1 , nproma , 1
+  q ( p , 1 : nz ) = 6.0
+  t ( p , 1 : 6 ) = 2.0
+  t ( p , 6 : nz ) = 0.0
+ END DO
+ CALL compute_column ( nz , q ( : , : ) , t ( : , : ) , nproma = nproma )
+ PRINT * , ( q ( 1 , i ) , i = 1 , 10 , 1 )
+END PROGRAM test_column_conditional
+

--- a/test/claw/abstraction/abstraction35/main.f90
+++ b/test/claw/abstraction/abstraction35/main.f90
@@ -1,0 +1,28 @@
+!
+! This file is released under terms of BSD license
+! See LICENSE file for more information
+!
+
+PROGRAM test_column_conditional
+  USE mo_column, ONLY: compute_column
+  REAL, DIMENSION(5,10) :: q, t, z  ! Fields as declared in the whole model
+  INTEGER :: nproma, nz             ! Size of array fields
+  INTEGER :: p                      ! Loop index
+
+  nproma = 5
+  nz = 10
+
+  DO p = 1, nproma
+    q(p, 1:nz) = 6.0
+    z(p, 1:nz) = 5.0
+    t(p, 1:6) = 2.0
+    t(p, 6:nz) = 0.0
+  END DO
+
+  !$claw parallelize forward
+  DO p = 1, nproma
+    CALL compute_column(nz, q(p,:), t(p,:), z(p,:))
+  END DO
+
+  PRINT*, (q(1, i), i=1,10)
+END PROGRAM test_column_conditional

--- a/test/claw/abstraction/abstraction35/mo_column.f90
+++ b/test/claw/abstraction/abstraction35/mo_column.f90
@@ -14,6 +14,7 @@ CONTAINS
     REAL, INTENT(INOUT)   :: t(:) ! Field declared as one column only
     REAL, INTENT(INOUT)   :: q(:) ! Field declared as one column only
     REAL, INTENT(INOUT)   :: z(:) ! Field declared as one column only
+    REAL :: tmp ! Temporary variable
     INTEGER :: k                  ! Loop index
 
     ! CLAW definition
@@ -28,11 +29,13 @@ CONTAINS
     DO k = 1, nz
       IF (t(k) > 0.) THEN
         IF(k < 10) THEN
+          tmp = tmp + q(k)
           q(k) = q(k) / t(k)
         END IF
       ELSE
         q(k) = q(k) * z(k)
       END IF
+      z(k) = z(k) * tmp
     END DO
   END SUBROUTINE compute_column
 END MODULE mo_column

--- a/test/claw/abstraction/abstraction35/mo_column.f90
+++ b/test/claw/abstraction/abstraction35/mo_column.f90
@@ -10,17 +10,16 @@ CONTAINS
   SUBROUTINE compute_column(nz, q, t, z)
     IMPLICIT NONE
 
-    INTEGER, INTENT(IN)   :: nz   ! Size of the array field
-    REAL, INTENT(INOUT)   :: t(:) ! Field declared as one column only
-    REAL, INTENT(INOUT)   :: q(:) ! Field declared as one column only
-    REAL, INTENT(INOUT)   :: z(:) ! Field declared as one column only
-    REAL :: tmp ! Temporary variable
-    INTEGER :: k                  ! Loop index
+    INTEGER, INTENT(IN)   :: nz   ! Vertical dimension size
+    REAL, INTENT(INOUT)   :: t(:) ! Field declared as single column only
+    REAL, INTENT(INOUT)   :: q(:) ! Field declared as single column only
+    REAL, INTENT(INOUT)   :: z(:) ! Field declared as single column only
+    REAL :: tmp, tmp2   ! Temporary variable
+    INTEGER :: k  ! Loop index over the verical dimension
 
     ! CLAW definition
-
-    ! Define one dimension that will be added to the variables defined in the
-    ! data clause.
+    ! Define horizontal dimension that will be added to the auto-detected
+    ! variables.
     ! Apply the parallelization transformation on this subroutine.
 
     !$claw define dimension proma(1:nproma) &
@@ -35,6 +34,7 @@ CONTAINS
       ELSE
         q(k) = q(k) * z(k)
       END IF
+      tmp2 = tmp + q(k)
       z(k) = z(k) * tmp
     END DO
   END SUBROUTINE compute_column

--- a/test/claw/abstraction/abstraction35/mo_column.f90
+++ b/test/claw/abstraction/abstraction35/mo_column.f90
@@ -1,0 +1,38 @@
+!
+! This file is released under terms of BSD license
+! See LICENSE file for more information
+!
+
+MODULE mo_column
+  IMPLICIT NONE
+CONTAINS
+  ! Compute only one column
+  SUBROUTINE compute_column(nz, q, t, z)
+    IMPLICIT NONE
+
+    INTEGER, INTENT(IN)   :: nz   ! Size of the array field
+    REAL, INTENT(INOUT)   :: t(:) ! Field declared as one column only
+    REAL, INTENT(INOUT)   :: q(:) ! Field declared as one column only
+    REAL, INTENT(INOUT)   :: z(:) ! Field declared as one column only
+    INTEGER :: k                  ! Loop index
+
+    ! CLAW definition
+
+    ! Define one dimension that will be added to the variables defined in the
+    ! data clause.
+    ! Apply the parallelization transformation on this subroutine.
+
+    !$claw define dimension proma(1:nproma) &
+    !$claw parallelize
+
+    DO k = 1, nz
+      IF (t(k) > 0.) THEN
+        IF(k < 10) THEN
+          q(k) = q(k) / t(k)
+        END IF
+      ELSE
+        q(k) = q(k) * z(k)
+      END IF
+    END DO
+  END SUBROUTINE compute_column
+END MODULE mo_column

--- a/test/claw/abstraction/abstraction35/reference_cpu.f90
+++ b/test/claw/abstraction/abstraction35/reference_cpu.f90
@@ -1,0 +1,37 @@
+MODULE mo_column
+
+CONTAINS
+ SUBROUTINE compute_column ( nz , q , t , z , nproma )
+
+  INTEGER , INTENT(IN) :: nz
+  REAL , INTENT(INOUT) :: t ( : , : )
+  REAL , INTENT(INOUT) :: q ( : , : )
+  REAL , INTENT(INOUT) :: z ( : , : )
+  INTEGER , INTENT(IN) :: nproma
+  REAL :: tmp ( 1 : nproma )
+  REAL :: tmp2 ( 1 : nproma )
+  INTEGER :: k
+  INTEGER :: proma
+
+  DO k = 1 , nz , 1
+   DO proma = 1 , nproma , 1
+    IF ( t ( proma , k ) > 0. ) THEN
+     IF ( k < 10 ) THEN
+      tmp ( proma ) = tmp ( proma ) + q ( proma , k )
+      q ( proma , k ) = q ( proma , k ) / t ( proma , k )
+     END IF
+    ELSE
+     q ( proma , k ) = q ( proma , k ) * z ( proma , k )
+    END IF
+   END DO
+   DO proma = 1 , nproma , 1
+    tmp2 ( proma ) = tmp ( proma ) + q ( proma , k )
+   END DO
+   DO proma = 1 , nproma , 1
+    z ( proma , k ) = z ( proma , k ) * tmp ( proma )
+   END DO
+  END DO
+ END SUBROUTINE compute_column
+
+END MODULE mo_column
+

--- a/test/claw/abstraction/abstraction35/reference_gpu.f90
+++ b/test/claw/abstraction/abstraction35/reference_gpu.f90
@@ -1,0 +1,39 @@
+MODULE mo_column
+
+CONTAINS
+ SUBROUTINE compute_column ( nz , q , t , z , nproma )
+
+  INTEGER , INTENT(IN) :: nz
+  REAL , INTENT(INOUT) :: t ( : , : )
+  REAL , INTENT(INOUT) :: q ( : , : )
+  REAL , INTENT(INOUT) :: z ( : , : )
+  INTEGER , INTENT(IN) :: nproma
+  REAL :: tmp
+  REAL :: tmp2
+  INTEGER :: k
+  INTEGER :: proma
+
+!$acc loop seq
+!$acc data present(t,q,z)
+!$acc parallel
+!$acc loop gang vector
+  DO proma = 1 , nproma , 1
+   DO k = 1 , nz , 1
+    IF ( t ( proma , k ) > 0. ) THEN
+     IF ( k < 10 ) THEN
+      tmp = tmp + q ( proma , k )
+      q ( proma , k ) = q ( proma , k ) / t ( proma , k )
+     END IF
+    ELSE
+     q ( proma , k ) = q ( proma , k ) * z ( proma , k )
+    END IF
+    tmp2 = tmp + q ( proma , k )
+    z ( proma , k ) = z ( proma , k ) * tmp
+   END DO
+  END DO
+!$acc end parallel
+!$acc end data
+ END SUBROUTINE compute_column
+
+END MODULE mo_column
+

--- a/test/claw/abstraction/abstraction35/reference_main_cpu.f90
+++ b/test/claw/abstraction/abstraction35/reference_main_cpu.f90
@@ -1,0 +1,23 @@
+PROGRAM test_column_conditional
+ USE mo_column , ONLY: compute_column
+ REAL :: q ( 1 : 5 , 1 : 10 )
+ REAL :: t ( 1 : 5 , 1 : 10 )
+ REAL :: z ( 1 : 5 , 1 : 10 )
+ INTEGER :: nproma
+ INTEGER :: nz
+ INTEGER :: p
+ INTEGER :: i
+
+ nproma = 5
+ nz = 10
+ DO p = 1 , nproma , 1
+  q ( p , 1 : nz ) = 6.0
+  z ( p , 1 : nz ) = 5.0
+  t ( p , 1 : 6 ) = 2.0
+  t ( p , 6 : nz ) = 0.0
+ END DO
+ CALL compute_column ( nz , q ( : , : ) , t ( : , : ) , z ( : , : ) , nproma =&
+  nproma )
+ PRINT * , ( q ( 1 , i ) , i = 1 , 10 , 1 )
+END PROGRAM test_column_conditional
+

--- a/test/claw/abstraction/abstraction35/reference_main_gpu.f90
+++ b/test/claw/abstraction/abstraction35/reference_main_gpu.f90
@@ -1,0 +1,23 @@
+PROGRAM test_column_conditional
+ USE mo_column , ONLY: compute_column
+ REAL :: q ( 1 : 5 , 1 : 10 )
+ REAL :: t ( 1 : 5 , 1 : 10 )
+ REAL :: z ( 1 : 5 , 1 : 10 )
+ INTEGER :: nproma
+ INTEGER :: nz
+ INTEGER :: p
+ INTEGER :: i
+
+ nproma = 5
+ nz = 10
+ DO p = 1 , nproma , 1
+  q ( p , 1 : nz ) = 6.0
+  z ( p , 1 : nz ) = 5.0
+  t ( p , 1 : 6 ) = 2.0
+  t ( p , 6 : nz ) = 0.0
+ END DO
+ CALL compute_column ( nz , q ( : , : ) , t ( : , : ) , z ( : , : ) , nproma =&
+  nproma )
+ PRINT * , ( q ( 1 , i ) , i = 1 , 10 , 1 )
+END PROGRAM test_column_conditional
+


### PR DESCRIPTION
## Status
<!-- Choose one of the following -->
**REVIEW**

## Description
* Issue #355 shows a bug in the CPU target transformation for SCA code. In this PR, we are trying new methods to categorize the assignment statement before inserting `DO` statement. Categorization will allow us to decide in a better way where to place the `DO` statement.

## Related issues
Issue #355
