### PR TITLE
Avoid infinite recursion if dependency cycle

### DIFF
--- a/driver/libexec/claw_f_lib.sh.in
+++ b/driver/libexec/claw_f_lib.sh.in
@@ -551,7 +551,9 @@ function claw::process_dependencies() {
     fi
 
     # Recurse to get dependencies in the right order
-    claw::process_dependencies "${file_pp}" "${base_file}"
+    if [[ "$2" != "${base_file}" ]]; then
+      claw::process_dependencies "${file_pp}" "${base_file}"
+    fi
 
     # Pass the module in the front-end to get the .xmod file
     # shellcheck disable=SC2086


### PR DESCRIPTION
## Status
<!-- Choose one of the following -->
**REVIEW**

## Description
* In some special cases, the dependency solver could be stuck in infinite recursion. This PR avoid this behavior.