### PR TITLE
Switch from omni-compiler to xcodeml-tools repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "omni-compiler"]
 	path = omni-compiler
-	url = https://github.com/omni-compiler/xcodeml-tools2.git
+	url = https://github.com/omni-compiler/xcodeml-tools.git
 	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "omni-compiler"]
 	path = omni-compiler
-	url = https://github.com/omni-compiler/omni-compiler.git
+	url = https://github.com/omni-compiler/xcodeml-tools2.git
 	branch = master

--- a/cx2t/claw.properties
+++ b/cx2t/claw.properties
@@ -22,10 +22,10 @@ commoncli.dep=${ivy.dir}/${commoncli.jar}
 
 # OMNI compiler libraries and paths
 omni.dir=${antfile.dir}/../../omni-compiler
-omni.exec.dir=${omni.dir}/XcodeML-Exc-Tools/build
+omni.xcodeml-common.dir=${omni.dir}/XcodeML-Common/build
 omni.backend.dir=${omni.dir}/F-BackEnd/build
-omni.exec.jar=om-exc-tools.jar
-omni.exec.dep=${omni.exec.dir}/${omni.exec.jar}
+omni.common.jar=om-common.jar
+omni.xcodeml-common.dep=${omni.xcodeml-common.dir}/${omni.common.jar}
 
 # CLAW X2T libraries
 claw.wani.jar=claw-x2t-wani.jar

--- a/cx2t/src/build.xml
+++ b/cx2t/src/build.xml
@@ -22,13 +22,12 @@
 
     <!-- Classpath for the CX2X Translator library -->
     <path id="build.path">
-        <pathelement path="${omni.exec.dep}"/>
         <pathelement path="${st4.dep}"/>
         <pathelement path="${antlr.dep}"/>
         <pathelement path="${antlr4.dep}"/>
         <pathelement path="${antlr4.runtime.dep}"/>
         <pathelement path="${commoncli.dep}"/>
-        <pathelement path="${omni.exec.dep}"/>
+        <pathelement path="${omni.xcodeml-common.dep}"/>
     </path>
 
     <path id="antlr.path">

--- a/cx2t/unittest/build.xml
+++ b/cx2t/unittest/build.xml
@@ -19,7 +19,6 @@
 
   <!-- Classpath for dependencies -->
   <path id="build.path">
-    <pathelement path="${omni.exec.dep}"/>
     <pathelement path="${junit.dep}" />
     <pathelement path="${st4.dep}"/>
     <pathelement path="${antlr.dep}"/>
@@ -29,6 +28,7 @@
     <pathelement path="${claw.tatsu.dep}" />
     <pathelement path="${claw.shenron.dep}" />
     <pathelement path="${claw.wani.dep}" />
+    <pathelement path="${omni.xcodeml-common.dep}"/>
   </path>
 
   <!-- Initialization step -->
@@ -75,7 +75,7 @@
       <classpath path="${antlr.dep}" />
       <classpath path="${antlr4.dep}" />
       <classpath path="${antlr4.runtime.dep}" />
-      <classpath path="${omni.exec.dep}"/>
+      <classpath path="${omni.xcodeml-common.dep}"/>
 
       <formatter type="plain" usefile="false" />
 
@@ -99,7 +99,7 @@
       <classpath path="${antlr.dep}" />
       <classpath path="${antlr4.dep}" />
       <classpath path="${antlr4.runtime.dep}" />
-      <classpath path="${omni.exec.dep}"/>
+      <classpath path="${omni.xcodeml-common.dep}"/>
 
       <formatter type="plain" usefile="false" />
 
@@ -124,7 +124,7 @@
       <classpath path="${antlr.dep}" />
       <classpath path="${antlr4.dep}" />
       <classpath path="${antlr4.runtime.dep}" />
-      <classpath path="${omni.exec.dep}"/>
+      <classpath path="${omni.xcodeml-common.dep}"/>
 
       <formatter type="plain" usefile="false" />
 

--- a/properties.cmake
+++ b/properties.cmake
@@ -43,7 +43,7 @@ set(OMNI_XMOD_GENERIC "${OMNI_HOME}/fincludes")
 set(OMNI_BIN_DIR "${OMNI_HOME}/bin")
 set(OMNI_F_FRONT "${OMNI_BIN_DIR}/F_Front")
 set(OMNI_C_FRONT "${OMNI_BIN_DIR}/C_Front")
-set(OMNI_JAR_TOOLS "${OMNI_CLASSPATH}/om-exc-tools.jar")
+set(OMNI_JAR_TOOLS "${OMNI_CLASSPATH}/om-common.jar")
 set(OMNI_JAR_F_BACKEND "${OMNI_CLASSPATH}/om-f-back.jar")
 set(OMNI_JAR_C_BACKEND "${OMNI_CLASSPATH}/om-c-back.jar")
 set(OMNI_F2X_FLAGS "")
@@ -54,7 +54,7 @@ set(CLAW_XMOD_GENERIC "${OMNI_HOME}/fincludes")
 # Define OMNI Compiler jar archives build location.
 set(
   BUILD_OMNI_JAR_TOOLS
-  "${CMAKE_SOURCE_DIR}/omni-compiler/XcodeML-Exc-Tools/build/om-exc-tools.jar"
+  "${CMAKE_SOURCE_DIR}/omni-compiler/XcodeML-Common/build/om-common.jar"
 )
 set(
   BUILD_OMNI_JAR_F_BACKEND


### PR DESCRIPTION
## Status
<!-- Choose one of the following -->
**REVIEW**

## Description
* OMNI Compiler base repository will not contain front-end and back-end anymore. These will be moved to `xcodeml-tools` submodule repository. 