### PR TITLE
Fix problem on OS X with missing mapfile command

### DIFF
--- a/driver/libexec/claw_f_lib.sh.in
+++ b/driver/libexec/claw_f_lib.sh.in
@@ -593,13 +593,23 @@ function claw::process_dependencies() {
 #   $1: input file path edited in place
 ###################################################################
 function claw::applyIgnore() {
-  # Retrieve the ignore start directives in the file
-  local startarray
-  mapfile -t startarray < <(grep -n "\\s*\\!\$claw ignore" "$1" | cut -f1 -d:)
+  if ! which mapfile > /dev/null; then
+    # workaround for OSX where mapfile is not available
+    # Retrieve the ignore start directives in the file
+    # shellcheck disable=SC2207
+    local startarray=($(grep -n "\\s*\\!\$claw ignore" "$1" | cut -f1 -d:))
+    # Retrieve the ignore end directives in the file
+    # shellcheck disable=SC2207
+    local endarray=($(grep -n "\\s*\\!\$claw end ignore" "$1" | cut -f1 -d:))
+  else
+    # Retrieve the ignore start directives in the file
+    local startarray
+    mapfile -t startarray < <(grep -n "\\s*\\!\$claw ignore" "$1" | cut -f1 -d:)
 
-  # Retrieve the ignore end directives in the file
-  local endarray
-  mapfile -t endarray < <(grep -n "\\s*\\!\$claw end ignore" "$1" | cut -f1 -d:)
+    # Retrieve the ignore end directives in the file
+    local endarray
+    mapfile -t endarray < <(grep -n "\\s*\\!\$claw end ignore" "$1" | cut -f1 -d:)
+  fi
 
   # Check that we have the same number of start and end directives
   local startlen=${#startarray[*]}


### PR DESCRIPTION
## Status
<!-- Choose one of the following -->
**REVIEW**

## Description
* Switch to other method if `mapfile` is not available like on OS X
