### PR TITLE
 Add warning for OpenMP/CPU usage

### DIFF
--- a/cx2t/src/claw/ClawX2T.java
+++ b/cx2t/src/claw/ClawX2T.java
@@ -260,6 +260,12 @@ public class ClawX2T {
       Configuration.get().setMaxColumns(maxColumns);
       Context.init(Configuration.get().getCurrentDirective(),
           Configuration.get().getCurrentTarget(), maxColumns);
+
+      if(Context.get().getCompilerDirective() == CompilerDirective.OPENACC) {
+        OpenAcc openaccGen = (OpenAcc) Context.get().getGenerator();
+        openaccGen.setExecutionMode(Configuration.get().openACC().getMode());
+      }
+
     } catch(Exception ex) {
       error("internal", 0, 0, ex.getMessage());
       return;

--- a/cx2t/src/claw/ClawX2T.java
+++ b/cx2t/src/claw/ClawX2T.java
@@ -260,11 +260,6 @@ public class ClawX2T {
       Configuration.get().setMaxColumns(maxColumns);
       Context.init(Configuration.get().getCurrentDirective(),
           Configuration.get().getCurrentTarget(), maxColumns);
-
-      if(Context.get().getCompilerDirective() == CompilerDirective.OPENACC) {
-        OpenAcc openaccGen = (OpenAcc) Context.get().getGenerator();
-        openaccGen.setExecutionMode(Configuration.get().openACC().getMode());
-      }
     } catch(Exception ex) {
       error("internal", 0, 0, ex.getMessage());
       return;

--- a/cx2t/src/claw/tatsu/common/Context.java
+++ b/cx2t/src/claw/tatsu/common/Context.java
@@ -46,7 +46,9 @@ public class Context {
                           int maxColumns)
   {
     _instance = new Context(compilerDirective, target, maxColumns);
-    if(_instance.getCompilerDirective() == CompilerDirective.OPENACC) {
+    if(_instance.getCompilerDirective() == CompilerDirective.OPENACC
+        && Configuration.get().openACC() != null)
+    {
       OpenAcc openaccGen = (OpenAcc) Context.get().getGenerator();
       openaccGen.setExecutionMode(Configuration.get().openACC().getMode());
     }

--- a/cx2t/src/claw/tatsu/common/Context.java
+++ b/cx2t/src/claw/tatsu/common/Context.java
@@ -46,12 +46,6 @@ public class Context {
                           int maxColumns)
   {
     _instance = new Context(compilerDirective, target, maxColumns);
-    if(_instance.getCompilerDirective() == CompilerDirective.OPENACC
-        && Configuration.get().openACC() != null)
-    {
-      OpenAcc openaccGen = (OpenAcc) Context.get().getGenerator();
-      openaccGen.setExecutionMode(Configuration.get().openACC().getMode());
-    }
   }
 
   public static Context get() {

--- a/cx2t/src/claw/tatsu/common/Context.java
+++ b/cx2t/src/claw/tatsu/common/Context.java
@@ -9,6 +9,7 @@ import claw.tatsu.directive.generator.DirectiveNone;
 import claw.tatsu.directive.generator.OpenAcc;
 import claw.tatsu.directive.generator.OpenMp;
 import claw.tatsu.xcodeml.module.ModuleCache;
+import claw.wani.x2t.configuration.Configuration;
 
 /**
  * @author clementval
@@ -45,6 +46,10 @@ public class Context {
                           int maxColumns)
   {
     _instance = new Context(compilerDirective, target, maxColumns);
+    if(_instance.getCompilerDirective() == CompilerDirective.OPENACC) {
+      OpenAcc openaccGen = (OpenAcc) Context.get().getGenerator();
+      openaccGen.setExecutionMode(Configuration.get().openACC().getMode());
+    }
   }
 
   public static Context get() {

--- a/cx2t/src/claw/wani/x2t/translator/ClawTranslatorDriver.java
+++ b/cx2t/src/claw/wani/x2t/translator/ClawTranslatorDriver.java
@@ -5,8 +5,10 @@
 package claw.wani.x2t.translator;
 
 import claw.shenron.transformation.TransformationGroup;
+import claw.tatsu.common.CompilerDirective;
 import claw.tatsu.common.Context;
 import claw.tatsu.common.Message;
+import claw.tatsu.common.Target;
 import claw.tatsu.primitive.Pragma;
 import claw.tatsu.xcodeml.exception.IllegalDirectiveException;
 import claw.tatsu.xcodeml.exception.IllegalTransformationException;
@@ -85,6 +87,13 @@ public class ClawTranslatorDriver {
     _translationUnit = (_xcodemlInputFile == null) ?
         XcodeProgram.createFromStdInput() :
         XcodeProgram.createFromFile(_xcodemlInputFile);
+
+    if(Configuration.get().getCurrentDirective() == CompilerDirective.OPENMP
+        && Configuration.get().getCurrentTarget() == Target.CPU)
+    {
+      _translationUnit.addWarning("Fine grain OpenMP directive generation " +
+          "is not advised for CPU target.", 0);
+    }
 
     if(_translationUnit == null) {
       abort();


### PR DESCRIPTION
## Status
<!-- Choose one of the following -->
**REVIEW**

## Description
* Combination of OpenMP fine grain directive generation + CPU target is known to give poor performance. Therefore, a warning is issued when user use this combination.

## Related issues
Issue #422 
