### PR TITLE
Forward Java compiler information from top Cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,8 @@ if(BUILD_OMNI)
         ${OMNI_COMPILER_SUBMODULE}/Makefile.am
         ${OMNI_COMPILER_SUBMODULE}/Makefile.in
       && CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER}
-      FC=${CMAKE_Fortran_COMPILER} ${OMNI_COMPILER_SUBMODULE}/configure
+      FC=${CMAKE_Fortran_COMPILER} JAVAC=${Java_JAVAC_EXECUTABLE} 
+      ${OMNI_COMPILER_SUBMODULE}/configure
       --prefix=${CMAKE_INSTALL_PREFIX} ${OMNI_TARGET} ${OMNI_CONF_OPTION}
       ${OMNI_MPI_CC} ${OMNI_MPI_FC}
     BUILD_COMMAND make # Not safe yet with -j


### PR DESCRIPTION
## Status
<!-- Choose one of the following -->
**REVIEW**

## Description
* Pass the same Java compiler information from the top cmake to the submodule build

