### PR TITLE
[SCA] CPU-smart-fusion: Additional test and bugfix for nested conditionals

### DIFF
--- a/cx2t/src/claw/wani/transformation/sca/Parallelize.java
+++ b/cx2t/src/claw/wani/transformation/sca/Parallelize.java
@@ -728,12 +728,10 @@ public class Parallelize extends ClawTransformation {
         }
 
         // We need to wrap the whole IF based on the condition
-        List<Xnode> condNode = node.matchAll(Xcode.CONDITION);
-        for (Xnode xnode : condNode) {
-          if (Condition.dependsOn(xnode, affectingVars)) {
+        Xnode condNode = node.firstChild().matchSibling(Xcode.CONDITION);
+        if (Condition.dependsOn(condNode, affectingVars)) {
             hooks.add(node);
             continue nodeLoop;
-          }
         }
 
         // We need to wrap the whole IF based on the statement inside

--- a/test/claw/sca/CMakeLists.txt
+++ b/test/claw/sca/CMakeLists.txt
@@ -40,6 +40,7 @@
 # sca35: CPU handle "if" correcly
 # sca36: Correct handling of indirect promotion
 # sca37: Check not mixed "!$acc loop seq" order directive generation
+# sca38: Check independent "if" handling for CPU target
 
 foreach(loop_var RANGE 1 37)
   if(NOT ${loop_var} EQUAL 30)

--- a/test/claw/sca/sca38/main.f90
+++ b/test/claw/sca/sca38/main.f90
@@ -1,0 +1,8 @@
+!
+! This file is released under terms of BSD license
+! See LICENSE file for more information
+!
+! Test the CLAW abstraction model with one additional dimension.
+!
+PROGRAM main
+END PROGRAM main

--- a/test/claw/sca/sca38/mo_column.f90
+++ b/test/claw/sca/sca38/mo_column.f90
@@ -8,16 +8,16 @@ MODULE mod1
   IMPLICIT NONE
 CONTAINS
   ! Compute only one column
-  SUBROUTINE compute_column(nz, q, t, z, flag)
+  SUBROUTINE compute_column(nz, q, t, z, flag, flag2)
     IMPLICIT NONE
 
     INTEGER, INTENT(IN)   :: nz   ! Vertical dimension size
     REAL, INTENT(INOUT)   :: t(nz) ! Field declared as single column only
     REAL, INTENT(INOUT)   :: q(nz) ! Field declared as single column only
     REAL, INTENT(INOUT)   :: z(nz) ! Field declared as single column only
-    LOGICAL, INTENT(IN)   :: flag  ! Flag to trigger a certain process
-    REAL :: tmp, tmp2   ! Temporary variable
-    INTEGER :: k  ! Loop index over the verical dimension
+    LOGICAL, INTENT(IN)   :: flag, flag2  ! Flags for certain processes
+    REAL :: tmp, tmp2, tmp3(nz, 5)   ! Temporary variable
+    INTEGER :: k, j  ! Loop index over the verical dimension
 
     ! CLAW definition of parallelization across the horizontal dimension.
 
@@ -34,7 +34,18 @@ CONTAINS
            z(k) = z(k) * tmp2
         END IF
       END DO
-   END IF
+    END IF
+
+    DO k=1, nz, 1
+       IF (flag) THEN
+          z(k) = z(k) + tmp
+          DO j=1, 5
+             IF (flag2) THEN
+                z(k) = z(k) * tmp3(k, j)
+             END IF
+          END DO
+       END IF
+    END DO
 
   END SUBROUTINE compute_column
 END MODULE mod1

--- a/test/claw/sca/sca38/mo_column.f90
+++ b/test/claw/sca/sca38/mo_column.f90
@@ -1,0 +1,40 @@
+!
+! This file is released under terms of BSD license
+! See LICENSE file for more information
+!
+! Test the CLAW abstraction model with one additional dimension.
+!
+MODULE mod1
+  IMPLICIT NONE
+CONTAINS
+  ! Compute only one column
+  SUBROUTINE compute_column(nz, q, t, z, flag)
+    IMPLICIT NONE
+
+    INTEGER, INTENT(IN)   :: nz   ! Vertical dimension size
+    REAL, INTENT(INOUT)   :: t(nz) ! Field declared as single column only
+    REAL, INTENT(INOUT)   :: q(nz) ! Field declared as single column only
+    REAL, INTENT(INOUT)   :: z(nz) ! Field declared as single column only
+    LOGICAL, INTENT(IN)   :: flag  ! Flag to trigger a certain process
+    REAL :: tmp, tmp2   ! Temporary variable
+    INTEGER :: k  ! Loop index over the verical dimension
+
+    ! CLAW definition of parallelization across the horizontal dimension.
+
+    !$claw define dimension proma(1:nproma) &
+    !$claw parallelize
+
+    DO k=1, nz, 1
+       q(k) = q(k) / t(k)
+    END DO
+
+    IF (flag) THEN
+      DO k=1, nz, 1
+        IF (z(k) < tmp) THEN
+           z(k) = z(k) * tmp2
+        END IF
+      END DO
+   END IF
+
+  END SUBROUTINE compute_column
+END MODULE mod1

--- a/test/claw/sca/sca38/reference_cpu.f90
+++ b/test/claw/sca/sca38/reference_cpu.f90
@@ -1,0 +1,39 @@
+MODULE mod1
+
+CONTAINS
+ SUBROUTINE compute_column ( nz , q , t , z , flag , nproma )
+  INTEGER , INTENT(IN) :: nproma
+
+  INTEGER , INTENT(IN) :: nz
+  REAL , INTENT(INOUT) :: t ( 1 : nproma , 1 : nz )
+  REAL , INTENT(INOUT) :: q ( 1 : nproma , 1 : nz )
+  REAL , INTENT(INOUT) :: z ( 1 : nproma , 1 : nz )
+  LOGICAL , INTENT(IN) :: flag
+  REAL :: tmp
+  REAL :: tmp2
+  INTEGER :: k
+  INTEGER :: proma
+
+!$acc parallel
+  DO k = 1 , nz , 1
+!$acc loop gang vector
+   DO proma = 1 , nproma , 1
+    q ( proma , k ) = q ( proma , k ) / t ( proma , k )
+   END DO
+  END DO
+  IF ( flag ) THEN
+   DO k = 1 , nz , 1
+!$acc loop gang vector
+    DO proma = 1 , nproma , 1
+     IF ( z ( proma , k ) < tmp ) THEN
+      z ( proma , k ) = z ( proma , k ) * tmp2
+     END IF
+    END DO
+   END DO
+  END IF
+!$acc end parallel
+ END SUBROUTINE compute_column
+
+END MODULE mod1
+
+

--- a/test/claw/sca/sca38/reference_cpu.f90
+++ b/test/claw/sca/sca38/reference_cpu.f90
@@ -31,6 +31,19 @@ CONTAINS
     END DO
    END DO
   END IF
+  DO k = 1 , nz , 1
+!$acc loop gang vector
+   DO proma = 1 , nproma , 1
+    IF ( flag ) THEN
+     z ( proma , k ) = z ( proma , k ) + tmp
+     DO j = 1 , 5 , 1
+      IF ( flag2 ) THEN
+       z ( proma , k ) = z ( proma , k ) * tmp3 ( k , j )
+      END IF
+     END DO
+    END IF
+   END DO
+  END DO
 !$acc end parallel
  END SUBROUTINE compute_column
 

--- a/test/claw/sca/sca38/reference_main_cpu.f90
+++ b/test/claw/sca/sca38/reference_main_cpu.f90
@@ -1,0 +1,8 @@
+!
+! This file is released under terms of BSD license
+! See LICENSE file for more information
+!
+! Test the CLAW abstraction model with one additional dimension.
+!
+PROGRAM main
+END PROGRAM main


### PR DESCRIPTION
## Status
**DISCUSSION**

## Description
This PR adds a test for handling nested conditionals to the new SCA-CPU "smart fusion" branch. 

It also provides a small bug fix for cases where nested `IF` nodes would cause double wrapping of a code block, as illustrated in the second code block in the included test (`sca38`). This one is easily fixed by changing the corresponding lookup in `wani.transformation.sca.Parallelize.transformFusionForCPUGather()`.

The new test also highlights a more complex bug, where again double-wrapping is triggered by nested `IF`/`LOOP` combinations (the last block in the new test). The problem is basically this:
```
IF (flag1) THEN
  z(k) = ...<depends only on k>
  DO j=1, 5 
    IF (flag2) THEN
      z(k) = ...<depends on k, j>
    END IF
  END DO
END IF
```

The problem, as far as I can see it, is that the "smart fusion" algorithm tries to lift the SCA wrapper loop above the `IF` nodes, but still triggers on each `IF` node independently. The scoping of this example though suggests that, if we were to wrap the outermost `IF`, the innermost `IF` cannot get wrapped to avoid double-wrapping. This means that the code triggering on the inner `IF` needs to be aware of the wrapper-scope above it, and that information is not available (currently). 

Alternatively, it is not necessarily obvious to me that we need to lift the SCA wrapper loop that far. Instead we could wrap the first statement (dependent only on index `k`) independently, while leaving the recursion in the `transformFusionForCPUGather()` routine to pick up the second statement (dependent on `j` and `k`). The result would potentially look like this:
```
IF (flag1) THEN
  DO proma=1, nproma
    z(proma, k) = ...
  END DO
  DO j=1, 5
    IF (flag2) THEN
      DO proma=1, nproma
        z(k) = ... <j, k>
      END DO
    END IF
  END DO
END IF
```

In general, it is not entirely obvious to me whether making the "smart fusion" greedy enough to go across SCA-independent IF conditions is a good idea or not. I can definitely see the rational behind it (longer fused regions) but I am not sure how to implement this bug-free. Any help on fixing this would be appreciated.

As a final note, I really like what this branch is trying to do, and I believe the above to be final show-stoppers for the very(!) complex kernel I'm currently working on (hopefully).

## Related issues
PR #432 
