### PR TITLE
Add parenthesis option from backend driven from driver

### DIFF
--- a/cx2t/src/claw/ClawX2T.java
+++ b/cx2t/src/claw/ClawX2T.java
@@ -127,6 +127,9 @@ public class ClawX2T {
     options.addOption("x", true,
         "override configuration option. Higher priority over base " +
             "configuration and user configuration.");
+    options.addOption("ap", "--add-paren", false,
+        "Force backend to add parenthesis in binary mathematical binary " +
+            "operation.");
     return options;
   }
 
@@ -282,6 +285,11 @@ public class ClawX2T {
     // Force pure option
     if(cmd.hasOption("fp")) {
       Configuration.get().setForcePure();
+    }
+
+    // Add parenthesis option
+    if(cmd.hasOption("ap")) {
+      XmOption.setAddPar(true);
     }
 
     ClawTranslatorDriver translatorDriver =

--- a/cx2t/src/claw/ClawX2T.java
+++ b/cx2t/src/claw/ClawX2T.java
@@ -127,7 +127,7 @@ public class ClawX2T {
     options.addOption("x", true,
         "override configuration option. Higher priority over base " +
             "configuration and user configuration.");
-    options.addOption("ap", "--add-paren", false,
+    options.addOption("ap", "add-paren", false,
         "Force backend to add parenthesis in binary mathematical binary " +
             "operation.");
     return options;

--- a/driver/bin/clawfc.in
+++ b/driver/bin/clawfc.in
@@ -54,6 +54,7 @@ force_pure=false
 report=false
 pipe_workflow=true
 keep_comment=false
+add_paren=false
 
 ### Set options ###
 # e.g.) clawfc -I/usr/lib myfile.f90
@@ -118,6 +119,7 @@ readonly force_pure
 readonly report
 readonly pipe_workflow
 readonly keep_comment
+readonly add_paren
 
 ### sed constant ###
 readonly claw_sed_ignore="s/\\!\$claw ignore//"

--- a/driver/libexec/claw_f_lib.sh.in
+++ b/driver/libexec/claw_f_lib.sh.in
@@ -53,6 +53,8 @@ CLAW Compiler options:
                                 directives.
    --force-pure               : force compiler to exit when transformation
                                 applied to PURE subroutine/function.
+   --add-paren                : Add parenthesis to binary operation in generated
+                                code.
    -r,--report                : generate the tranformation report.
    --debug                    : display transformation debug information.
    --debug-omni               : save intermediate files in __omni_tmp__ and
@@ -256,6 +258,7 @@ function claw::set_parameters() {
       enable_debug_omni=true
       ;;
     --force-pure) force_pure=true ;;
+    --add-paren) add_paren=true ;;
     -r | --report) report=true ;;
     *) other_args+=("$1") ;;
     esac
@@ -751,6 +754,10 @@ function claw::format_cx2t_params() {
 
   if [[ ${force_pure} == true ]]; then
     CLAW_X2T_TRANSLATOR_OPT="${CLAW_X2T_TRANSLATOR_OPT} --force-pure"
+  fi
+
+  if [[ ${add_paren} == true ]]; then
+    CLAW_X2T_TRANSLATOR_OPT="${CLAW_X2T_TRANSLATOR_OPT} --add-paren"
   fi
 
   # Module search path option

--- a/test/driver/CMakeLists.txt
+++ b/test/driver/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 # Information for specific test cases
 # -----------------------------------
+# add_paren: Test --add-paren driver option
 # backslash_preprocessor: Workaround for \ at end of line
 # dependencies1: multiple dependencies with subfolder
 # dependencies2: one dependency in a subfolder
@@ -58,5 +59,7 @@ set(NOCOMPILE_external1 ON)
 set(CLAW_TRANS_SET_PATH "${PROJECT_BINARY_DIR}/build/")
 
 set(CLAW_FLAGS_keep_comment --force --keep-comment)
+
+set(CLAW_FLAGS_add_paren --force --add-paren)
 
 claw_add_basic_test_set(NAME driver DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/driver/add_paren/original_code.f90
+++ b/test/driver/add_paren/original_code.f90
@@ -1,0 +1,9 @@
+!
+! This file is released under terms of BSD license
+! See LICENSE file for more information
+!
+PROGRAM add_paren
+  INTEGER :: a, b, c, res
+
+  res = a + b + c
+END PROGRAM add_paren

--- a/test/driver/add_paren/reference.f90
+++ b/test/driver/add_paren/reference.f90
@@ -1,0 +1,9 @@
+PROGRAM add_paren
+ INTEGER :: a
+ INTEGER :: b
+ INTEGER :: c
+ INTEGER :: res
+
+ res = ( ( a + b ) + c )
+END PROGRAM add_paren
+


### PR DESCRIPTION
## Status
<!-- Choose one of the following -->
**REVIEW**

## Description
* New option `--add-paren` allows to force parenthesis in mathematical binary operations. 
