### PR TITLE
Fix #478: Pass correctly arguments to dependency resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ information: [OMNI Compiler website](http://omni-compiler.org)
 
 
 #### About
-This work was initially funded by the ETH zürich and the PASC initiative under
-the [ENIAC](http://www.pasc-ch.org/projects/2017-2020/eniac/) project.
+This work was initially funded by the ETH zürich, MeteoSwiss and the PASC
+initiative under the [ENIAC](http://www.pasc-ch.org/projects/2017-2020/eniac/)
+project.
 
 ---
 Logo by [adrienbachmann.ch](http://www.adrienbachmann.ch)

--- a/driver/libexec/claw_f_lib.sh.in
+++ b/driver/libexec/claw_f_lib.sh.in
@@ -581,9 +581,7 @@ function claw::process_dependencies() {
 
     # shellcheck disable=SC2154
     if [[ "${fpp_redirect}" == true ]]; then
-      echo "${OMNI_FPP_CMD} ${include_opt[@]} ${pp_add_opt[@]} ${OMNI_FPP_OPT} ${other_args[@]} ${base_file} > ${file_pp}"
       # shellcheck disable=SC2086,SC2068
-
       ${OMNI_FPP_CMD} ${include_opt[@]} ${pp_add_opt[@]} ${OMNI_FPP_OPT} \
         ${other_args[@]} "${base_file}" > "${file_pp}"
     else

--- a/driver/libexec/claw_f_lib.sh.in
+++ b/driver/libexec/claw_f_lib.sh.in
@@ -555,7 +555,7 @@ function claw::process_dependencies() {
     elif [[ ${source_mod_file_found} == true ]] &&
       [[ ${compiled_mod_file_found} == true ]]; then
       if [[ ${compiled_mod_file} -nt ${source_mod_file} ]]; then
-        claw::verbose "Info: module file for ${module_name} seems up-to-date"
+        claw::verbose "Info: module file for ${module_name} seems up-to-date (${compiled_mod_file})"
         continue
       fi
     fi
@@ -581,7 +581,9 @@ function claw::process_dependencies() {
 
     # shellcheck disable=SC2154
     if [[ "${fpp_redirect}" == true ]]; then
+      echo "${OMNI_FPP_CMD} ${include_opt[@]} ${pp_add_opt[@]} ${OMNI_FPP_OPT} ${other_args[@]} ${base_file} > ${file_pp}"
       # shellcheck disable=SC2086,SC2068
+
       ${OMNI_FPP_CMD} ${include_opt[@]} ${pp_add_opt[@]} ${OMNI_FPP_OPT} \
         ${other_args[@]} "${base_file}" > "${file_pp}"
     else

--- a/driver/libexec/claw_f_lib.sh.in
+++ b/driver/libexec/claw_f_lib.sh.in
@@ -581,13 +581,13 @@ function claw::process_dependencies() {
 
     # shellcheck disable=SC2154
     if [[ "${fpp_redirect}" == true ]]; then
-      # shellcheck disable=SC2086
-      ${OMNI_FPP_CMD} "${include_opt[@]}" "${pp_add_opt[@]}" ${OMNI_FPP_OPT} \
-        "${other_args[@]}" "${base_file}" >"${file_pp}"
+      # shellcheck disable=SC2086,SC2068
+      ${OMNI_FPP_CMD} ${include_opt[@]} ${pp_add_opt[@]} ${OMNI_FPP_OPT} \
+        ${other_args[@]} "${base_file}" > "${file_pp}"
     else
-      # shellcheck disable=SC2086
-      ${OMNI_FPP_CMD} "${include_opt[@]}" "${pp_add_opt[@]}" ${OMNI_FPP_OPT} \
-        "${other_args[@]}" "${base_file}"
+      # shellcheck disable=SC2086,SC2068
+      ${OMNI_FPP_CMD} ${include_opt[@]} ${pp_add_opt[@]} ${OMNI_FPP_OPT} \
+        ${other_args[@]} "${base_file}"
       mv "${dep_basename}.i" "${file_pp}"
     fi
 

--- a/test/driver/CMakeLists.txt
+++ b/test/driver/CMakeLists.txt
@@ -26,7 +26,7 @@
 set(CLAW_FLAGS_backslash_preprocessor --force)
 set(NOCOMPILE_backslash_preprocessor ON)
 
-set(CLAW_FLAGS_dependencies1 --force -J subfolder/)
+set(CLAW_FLAGS_dependencies1 --force -J subfolder/ -D__DEP2__ --verbose)
 set(NOCOMPILE_dependencies1 ON)
 
 set(CLAW_FLAGS_dependencies2 --force -J subfolder/)

--- a/test/driver/dependencies1/mod2.f90
+++ b/test/driver/dependencies1/mod2.f90
@@ -5,4 +5,9 @@
 
 module mod2
   use mod4
+
+#ifdef __DEP2__
+  integer :: i
+#endif
+
 end module mod2

--- a/test/driver/dependencies1/original_code.f90
+++ b/test/driver/dependencies1/original_code.f90
@@ -4,6 +4,6 @@
 !
 
 module mod1
-  use mod2
+  use mod2, ONLY: i
   use mod3
 end module mod1

--- a/test/driver/dependencies1/reference.f90
+++ b/test/driver/dependencies1/reference.f90
@@ -1,5 +1,5 @@
 MODULE mod1
- USE mod2
+ USE mod2 , ONLY: i
  USE mod3
 END MODULE mod1
 


### PR DESCRIPTION
## Status
<!-- Choose one of the following -->
**REVIEW**

## Description
* Pass args with splitting to the preprocessor

## Related issues
Issue #478 

