### PR TITLE
Avoid checking multiple times for the same module

### DIFF
--- a/driver/libexec/claw_f_lib.sh.in
+++ b/driver/libexec/claw_f_lib.sh.in
@@ -455,7 +455,9 @@ function claw::process_dependencies() {
   while IFS= read -r line; do
     if [[ ${line} =~ ${module_regex} ]]; then
       module_name="${BASH_REMATCH[3]}"
-      dependencies+=("${module_name}")
+      if [[ ! " ${dependencies[@]} " =~ " ${module_name} " ]]; then
+        dependencies+=("${module_name}")
+      fi
     fi
   done <"$1"
 


### PR DESCRIPTION
## Status
<!-- Choose one of the following -->
**REVIEW**

## Description
* Dependency solver will now check only once for module if there is multiple `USE` statement for the same module
