### PR TITLE
Add option to drive OMNI F_Front debug

### DIFF
--- a/driver/bin/clawfc.in
+++ b/driver/bin/clawfc.in
@@ -55,6 +55,7 @@ report=false
 pipe_workflow=true
 keep_comment=false
 add_paren=false
+omni_ffront_debug=false
 
 ### Set options ###
 # e.g.) clawfc -I/usr/lib myfile.f90
@@ -120,6 +121,7 @@ readonly report
 readonly pipe_workflow
 readonly keep_comment
 readonly add_paren
+readonly omni_ffront_debug
 
 ### sed constant ###
 readonly claw_sed_ignore="s/\\!\$claw ignore//"
@@ -154,11 +156,17 @@ if [[ ${show_config} == true ]]; then
   exit 0
 fi
 
+### Add front-end debug option
+if [[ ${omni_ffront_debug} == true ]]; then
+OMNI_F2X_OPT="${OMNI_F2X_OPT} -d"
+fi
+
 ### Add front-end option to keep the comment
 if [[ ${keep_comment} == true ]]; then
   OMNI_F2X_OPT="${OMNI_F2X_OPT} -fleave-comment"
-  readonly OMNI_F2X_OPT
 fi
+
+readonly OMNI_F2X_OPT
 
 # Add debug flag for the translator options
 if [[ ${enable_debug} == true ]]; then

--- a/driver/libexec/claw_f_lib.sh.in
+++ b/driver/libexec/claw_f_lib.sh.in
@@ -59,6 +59,7 @@ CLAW Compiler options:
    --debug                    : display transformation debug information.
    --debug-omni               : save intermediate files in __omni_tmp__ and
                                 display driver information.
+   --debug-ffront             : Drive OMNI Fortran front-end in debug mode.
    --stop-pp                  : save intermediate files and stop after
                                 preprocess.
    --stop-dependencies        : save intermediate files and stop after
@@ -192,7 +193,7 @@ function claw::set_parameters() {
       enable_debug_omni=true
       pipe_workflow=false
       ;;
-    --debug-front)
+    --debug-ffront)
       omni_ffront_debug=true
       ;;
     --stop-pp)

--- a/driver/libexec/claw_f_lib.sh.in
+++ b/driver/libexec/claw_f_lib.sh.in
@@ -192,6 +192,9 @@ function claw::set_parameters() {
       enable_debug_omni=true
       pipe_workflow=false
       ;;
+    --debug-front)
+      omni_ffront_debug=true
+      ;;
     --stop-pp)
       verbose=true
       stop_pp=true


### PR DESCRIPTION
## Status
<!-- Choose one of the following -->
**REVIEW**

## Description
* `--debug-ffront` will drive OMNI Fortran front-end in debug mode

