### PR TITLE
Fix #498: Redirect to file only if -o is provided

### DIFF
--- a/driver/bin/clawfc.in
+++ b/driver/bin/clawfc.in
@@ -343,18 +343,31 @@ if [[ ${pipe_workflow} == true ]]; then
         file_pp="${input_file}"
       fi
 
-      # shellcheck disable=SC2086,SC2068
-      ${OMNI_F2X_CMD} "${include_opt[@]}" "${module_opt[@]}" \
-        "${frontend_add_opt[@]}" ${OMNI_F2X_OPT} "${file_pp}" |
-        ${OMNI_FX2X_CMD} ${OMNI_FX2X_OPT} ${CLAW_X2T_TRANSLATOR_OPT} \
-          ${CLAW_X2T_TARGET_OPT} ${CLAW_X2T_DIRECTIVE_OPT} \
-          ${CLAW_X2T_CONFIG_OPT} ${CLAW_X2T_MODEL_CONFIG_OPT} \
-          ${CLAW_X2T_MAX_COLUMN_OPT} ${CLAW_X2T_LINE_OPT} \
-          "${xcode_translator_add_opt[@]}" "${module_opt[@]}" \
-          "${trans_module_opt[@]}" "${override_config_opt[@]}" |
-        sed -e "${claw_sed_ignore}" | sed -e "${claw_sed_end_ignore}" |
-        sed -e "${claw_sed_cont}" | sed -e "${claw_sed_verbatim}" >"${file_out_f}"
-
+      if [[ "${file_out_f}" != "" ]]; then
+        # shellcheck disable=SC2086,SC2068
+        ${OMNI_F2X_CMD} "${include_opt[@]}" "${module_opt[@]}" \
+          "${frontend_add_opt[@]}" ${OMNI_F2X_OPT} "${file_pp}" |
+          ${OMNI_FX2X_CMD} ${OMNI_FX2X_OPT} ${CLAW_X2T_TRANSLATOR_OPT} \
+            ${CLAW_X2T_TARGET_OPT} ${CLAW_X2T_DIRECTIVE_OPT} \
+            ${CLAW_X2T_CONFIG_OPT} ${CLAW_X2T_MODEL_CONFIG_OPT} \
+            ${CLAW_X2T_MAX_COLUMN_OPT} ${CLAW_X2T_LINE_OPT} \
+            "${xcode_translator_add_opt[@]}" "${module_opt[@]}" \
+            "${trans_module_opt[@]}" "${override_config_opt[@]}" |
+          sed -e "${claw_sed_ignore}" | sed -e "${claw_sed_end_ignore}" |
+          sed -e "${claw_sed_cont}" | sed -e "${claw_sed_verbatim}" > "${file_out_f}"
+      else
+        # shellcheck disable=SC2086,SC2068
+        ${OMNI_F2X_CMD} "${include_opt[@]}" "${module_opt[@]}" \
+          "${frontend_add_opt[@]}" ${OMNI_F2X_OPT} "${file_pp}" |
+          ${OMNI_FX2X_CMD} ${OMNI_FX2X_OPT} ${CLAW_X2T_TRANSLATOR_OPT} \
+            ${CLAW_X2T_TARGET_OPT} ${CLAW_X2T_DIRECTIVE_OPT} \
+            ${CLAW_X2T_CONFIG_OPT} ${CLAW_X2T_MODEL_CONFIG_OPT} \
+            ${CLAW_X2T_MAX_COLUMN_OPT} ${CLAW_X2T_LINE_OPT} \
+            "${xcode_translator_add_opt[@]}" "${module_opt[@]}" \
+            "${trans_module_opt[@]}" "${override_config_opt[@]}" |
+          sed -e "${claw_sed_ignore}" | sed -e "${claw_sed_end_ignore}" |
+          sed -e "${claw_sed_cont}" | sed -e "${claw_sed_verbatim}"
+      fi
       # 0: OMNI FORTRAN Front-end
       # 1: CLAW XcodeML Translator
       # 2: !$claw ignore     # revert pass


### PR DESCRIPTION
## Status
<!-- Choose one of the following -->
**REVIEW**

## Description
* When using piped workflow, redirect only when `-o` is provided on the command line

## Related issues
Issue #498 
