### PR TITLE
[SCA] Force promotion with assumed shape array when possible in ELEMENTAL function/subroutine

### DIFF
--- a/cx2t/src/claw/tatsu/primitive/Field.java
+++ b/cx2t/src/claw/tatsu/primitive/Field.java
@@ -97,7 +97,7 @@ public final class Field {
     fieldInfo.setBaseDimension(newType.getDimensions());
     fieldInfo.setTargetDimension(newType.getDimensions() +
         fieldInfo.getDimensions().size());
-    fieldInfo.setTargetType(type);
+    fieldInfo.setTargetType(newType);
 
     if(fieldInfo.getPromotionType() ==
         PromotionInfo.PromotionType.ARRAY_TO_ARRAY)

--- a/cx2t/src/claw/tatsu/primitive/Field.java
+++ b/cx2t/src/claw/tatsu/primitive/Field.java
@@ -134,7 +134,12 @@ public final class Field {
       }
     } else { // SCALAR to ARRAY promotion
       for(DimensionDefinition dim : fieldInfo.getDimensions()) {
-        Xnode index = dim.generateIndexRange(xcodeml, false);
+        Xnode index;
+        if(fieldInfo.isForcedAssumedShape()) {
+          index = xcodeml.createEmptyAssumedShaped();
+        } else {
+          index = dim.generateIndexRange(xcodeml, false);
+        }
         newType.addDimension(index);
       }
     }

--- a/cx2t/src/claw/tatsu/primitive/Loop.java
+++ b/cx2t/src/claw/tatsu/primitive/Loop.java
@@ -18,7 +18,6 @@ import claw.tatsu.xcodeml.xnode.common.Xscope;
 import claw.tatsu.xcodeml.xnode.fortran.FbasicType;
 import claw.tatsu.xcodeml.xnode.fortran.FortranType;
 import claw.tatsu.xcodeml.xnode.fortran.Xintrinsic;
-import claw.wani.ClawConstant;
 
 import java.util.List;
 

--- a/cx2t/src/claw/tatsu/primitive/Loop.java
+++ b/cx2t/src/claw/tatsu/primitive/Loop.java
@@ -14,6 +14,11 @@ import claw.tatsu.xcodeml.xnode.XnodeUtil;
 import claw.tatsu.xcodeml.xnode.common.Xcode;
 import claw.tatsu.xcodeml.xnode.common.XcodeML;
 import claw.tatsu.xcodeml.xnode.common.Xnode;
+import claw.tatsu.xcodeml.xnode.common.Xscope;
+import claw.tatsu.xcodeml.xnode.fortran.FbasicType;
+import claw.tatsu.xcodeml.xnode.fortran.FortranType;
+import claw.tatsu.xcodeml.xnode.fortran.Xintrinsic;
+import claw.wani.ClawConstant;
 
 import java.util.List;
 
@@ -452,4 +457,50 @@ public final class Loop {
   public static boolean hasSameIndexRangeBesidesLower(Xnode l1, Xnode l2) {
     return compareIndexRanges(l1, l2, false);
   }
+
+  /**
+   * Create a do statement to iterate over an array from 1 to size.
+   *
+   * @param fbt          FbasicType of the array.
+   * @param arrayName    Array name.
+   * @param inductionVar Identifier of a the induction variable.
+   * @param dimId        Dimension on which size is called.
+   * @param xcodeml      Current translation unit.
+   * @return Newly created node.
+   */
+  public static Xnode createDoStmtOverAssumedShapeArray(FbasicType fbt,
+                                                        String arrayName,
+                                                        String inductionVar,
+                                                        int dimId,
+                                                        XcodeML xcodeml)
+  {
+    // Induction variable
+    Xnode induction =
+        xcodeml.createVar(FortranType.INTEGER, inductionVar, Xscope.LOCAL);
+
+    // Lower bound
+    Xnode lb = xcodeml.createNode(Xcode.LOWER_BOUND);
+    lb.append(xcodeml.createIntConstant(1));
+
+    // upper bound
+    Xnode up = xcodeml.createNode(Xcode.UPPER_BOUND);
+    Xnode sizeCall =
+        xcodeml.createIntrinsicFctCall(FortranType.INTEGER, Xintrinsic.SIZE);
+    Xnode varArg = xcodeml.createVar(fbt.getType(), arrayName, Xscope.LOCAL);
+    Xnode dimArg = xcodeml.createIntConstant(dimId);
+    sizeCall.matchDescendant(Xcode.ARGUMENTS).append(varArg);
+    sizeCall.matchDescendant(Xcode.ARGUMENTS).append(dimArg);
+    up.append(sizeCall);
+
+    // step
+    Xnode step = xcodeml.createNode(Xcode.STEP);
+    step.append(xcodeml.createIntConstant(1));
+
+    Xnode range = xcodeml.createNode(Xcode.INDEX_RANGE);
+    range.append(lb);
+    range.append(up);
+    range.append(step);
+    return xcodeml.createDoStmt(induction, range);
+  }
+
 }

--- a/cx2t/src/claw/tatsu/primitive/Type.java
+++ b/cx2t/src/claw/tatsu/primitive/Type.java
@@ -35,12 +35,12 @@ public class Type {
    * @return The new type hash generated.
    * @throws IllegalTransformationException If action is not supported.
    */
-  public static String duplicateWithDimension(FbasicType base,
-                                              FbasicType toUpdate,
-                                              XcodeML xcodemlSrc,
-                                              XcodeML xcodemlDst,
-                                              List<DimensionDefinition>
-                                                  dimensions)
+  public static FbasicType duplicateWithDimension(FbasicType base,
+                                                  FbasicType toUpdate,
+                                                  XcodeML xcodemlSrc,
+                                                  XcodeML xcodemlDst,
+                                                  List<DimensionDefinition>
+                                                      dimensions)
       throws IllegalTransformationException
   {
     FbasicType newType = toUpdate.cloneNode();
@@ -94,7 +94,7 @@ public class Type {
     }
 
     xcodemlDst.getTypeTable().add(newType);
-    return type;
+    return newType;
   }
 
   /**

--- a/cx2t/src/claw/tatsu/primitive/Xmod.java
+++ b/cx2t/src/claw/tatsu/primitive/Xmod.java
@@ -212,7 +212,7 @@ public final class Xmod {
                 pLocal.getAttribute(Xattr.PROMOTION_INFO));
 
             if(lType.isArray()) {
-              String newType = Type.duplicateWithDimension(lType, crtType,
+              FbasicType newType = Type.duplicateWithDimension(lType, crtType,
                   xcodeml, mod, promotionInfo.getDimensions());
               pMod.setType(newType);
             }

--- a/cx2t/src/claw/tatsu/xcodeml/abstraction/NestedDoStatement.java
+++ b/cx2t/src/claw/tatsu/xcodeml/abstraction/NestedDoStatement.java
@@ -6,6 +6,7 @@ package claw.tatsu.xcodeml.abstraction;
 
 import claw.tatsu.primitive.Loop;
 import claw.tatsu.xcodeml.xnode.common.*;
+import claw.tatsu.xcodeml.xnode.fortran.FbasicType;
 import claw.tatsu.xcodeml.xnode.fortran.FortranType;
 
 import java.util.ArrayList;
@@ -63,8 +64,8 @@ public class NestedDoStatement {
    * the inner statement represents the last element of the list.
    *
    * @param dimensions A list of dimension objects.
-   * @param xcodeml    The current XcodeML program unit in which the elements
-   *                   will be created.
+   * @param xcodeml    The current XcodeML translation unit in which the
+   *                   elements will be created.
    */
   public NestedDoStatement(List<DimensionDefinition> dimensions,
                            XcodeProgram xcodeml)
@@ -74,11 +75,33 @@ public class NestedDoStatement {
       Xnode induction = xcodeml.createVar(FortranType.INTEGER,
           dim.getIdentifier(), Xscope.LOCAL);
       Xnode range = dim.generateIndexRange(xcodeml, true);
-      Xnode doSt = xcodeml.createDoStmt(induction, range);
+      Xnode doStmt = xcodeml.createDoStmt(induction, range);
       if(!_statements.isEmpty()) {
-        _statements.get(_statements.size() - 1).body().append(doSt);
+        _statements.get(_statements.size() - 1).body().append(doStmt);
       }
-      _statements.add(doSt);
+      _statements.add(doStmt);
+    }
+  }
+
+  /**
+   * Constructs a group of nested do statements from a promotion information
+   * object to iterate over assumed shape arrays.
+   *
+   * @param pi      Promotion information of one array taken as basis for the
+   *                iteration.
+   * @param xcodeml The current XcodeML translation unit in which the
+   *                elements will be created.
+   */
+  public NestedDoStatement(List<DimensionDefinition> dimensions,
+                           PromotionInfo pi, XcodeProgram xcodeml)
+  {
+    _statements = new ArrayList<>();
+    int index = 1;
+    for(DimensionDefinition dim : dimensions) {
+      _statements.add(Loop.createDoStmtOverAssumedShapeArray(
+          pi.getTargetType(), pi.getIdentifier(), dim.getIdentifier(),
+          index, xcodeml));
+      ++index;
     }
   }
 

--- a/cx2t/src/claw/tatsu/xcodeml/abstraction/PromotionInfo.java
+++ b/cx2t/src/claw/tatsu/xcodeml/abstraction/PromotionInfo.java
@@ -22,6 +22,7 @@ public class PromotionInfo {
   private PromotionType _promotionType = PromotionType.ARRAY_TO_ARRAY; //Default
   private boolean _referenceAdapted = false;
   private boolean _allocateAdapted = false;
+  private boolean _forceAssumendShape = false;
 
   /**
    * Default ctor. Used for global promotion information not attached to a
@@ -304,6 +305,14 @@ public class PromotionInfo {
         _dimensions.add(dim);
       }
     }
+  }
+
+  public void forceAssumedShape() {
+    _forceAssumendShape = true;
+  }
+
+  public boolean isForcedAssumedShape() {
+    return _forceAssumendShape;
   }
 
   // Type of promotion

--- a/cx2t/src/claw/tatsu/xcodeml/abstraction/PromotionInfo.java
+++ b/cx2t/src/claw/tatsu/xcodeml/abstraction/PromotionInfo.java
@@ -4,6 +4,8 @@
  */
 package claw.tatsu.xcodeml.abstraction;
 
+import claw.tatsu.xcodeml.xnode.fortran.FbasicType;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,7 +19,7 @@ public class PromotionInfo {
   private String _identifier;
   private int _baseDimension;
   private int _targetDimension;
-  private String _targetType;
+  private FbasicType _targetType;
   private List<DimensionDefinition> _dimensions;
   private PromotionType _promotionType = PromotionType.ARRAY_TO_ARRAY; //Default
   private boolean _referenceAdapted = false;
@@ -63,7 +65,7 @@ public class PromotionInfo {
    * @param targetType      Type if after the promotion.
    */
   public PromotionInfo(String id, int baseDimension, int targetDimension,
-                       String targetType)
+                       FbasicType targetType)
   {
     _identifier = id;
     _baseDimension = baseDimension;
@@ -112,7 +114,7 @@ public class PromotionInfo {
    *
    * @return Type id.
    */
-  public String getTargetType() {
+  public FbasicType getTargetType() {
     return _targetType;
   }
 
@@ -121,7 +123,7 @@ public class PromotionInfo {
    *
    * @param value Type hash value.
    */
-  public void setTargetType(String value) {
+  public void setTargetType(FbasicType value) {
     _targetType = value;
   }
 

--- a/cx2t/src/claw/tatsu/xcodeml/xnode/common/XcodeML.java
+++ b/cx2t/src/claw/tatsu/xcodeml/xnode/common/XcodeML.java
@@ -491,9 +491,34 @@ public class XcodeML extends Xnode {
     fctCall.setType(returnType);
     Xnode fctNameNode = createNode(Xcode.NAME);
     fctNameNode.setValue(fctName);
-    fctNameNode.setType(fctType);
+    if(fctType != null) {
+      fctNameNode.setType(fctType);
+    }
     fctCall.append(fctNameNode);
     fctCall.append(createNode(Xcode.ARGUMENTS));
+    return fctCall;
+  }
+
+  /**
+   * Create a new functionCall node with name and arguments as children nodes.
+   *
+   * {@code
+   * <functionCall type="returnType">
+   * <name type="fctType">fctName</name>
+   * <arguments></arguments>
+   * </functionCall>
+   * }
+   *
+   * @param returnType Value of the type attribute for the functionCall node.
+   * @param fctName    Value of the name node.
+   * @return The newly created node detached in the current XcodeML unit.
+   */
+  public Xnode createIntrinsicFctCall(FortranType returnType,
+                                      Xintrinsic fctName)
+  {
+    Xnode fctCall =
+        createFctCall(returnType.toString(), fctName.toString(), null);
+    fctCall.setBooleanAttribute(Xattr.IS_INTRINSIC, true);
     return fctCall;
   }
 

--- a/cx2t/src/claw/tatsu/xcodeml/xnode/common/Xnode.java
+++ b/cx2t/src/claw/tatsu/xcodeml/xnode/common/Xnode.java
@@ -5,6 +5,7 @@
 package claw.tatsu.xcodeml.xnode.common;
 
 import claw.tatsu.xcodeml.xnode.Xname;
+import claw.tatsu.xcodeml.xnode.fortran.FbasicType;
 import claw.tatsu.xcodeml.xnode.fortran.FfunctionDefinition;
 import claw.tatsu.xcodeml.xnode.fortran.FmoduleDefinition;
 import claw.tatsu.xcodeml.xnode.fortran.FortranType;
@@ -830,6 +831,14 @@ public class Xnode {
       default:
         return getAttribute(Xattr.TYPE);
     }
+  }
+
+  /**
+   *
+   * @param type
+   */
+  public void setType(FbasicType type) {
+    setAttribute(Xattr.TYPE, type.getType());
   }
 
   /**

--- a/cx2t/src/claw/wani/transformation/sca/Sca.java
+++ b/cx2t/src/claw/wani/transformation/sca/Sca.java
@@ -372,10 +372,17 @@ public class Sca extends ClawTransformation {
         _promotions.put(fieldId, promotionInfo);
       }
     } else {
+      boolean forceAssumedShape = _fctType.isElemental() &&
+          Configuration.get().getBooleanParameter(
+              Configuration.SCA_ELEMENTAL_PROMOTION_ASSUMED);
+
       // Promote all arrays in a similar manner
       for(String fieldId : _arrayFieldsInOut) {
         PromotionInfo promotionInfo = new PromotionInfo(fieldId,
             _claw.getLayoutForData(fieldId));
+        if(forceAssumedShape) {
+          promotionInfo.forceAssumedShape();
+        }
         Field.promote(promotionInfo, _fctDef, xcodeml);
         _promotions.put(fieldId, promotionInfo);
       }

--- a/cx2t/src/claw/wani/transformation/sca/ScaForward.java
+++ b/cx2t/src/claw/wani/transformation/sca/ScaForward.java
@@ -526,7 +526,7 @@ public class ScaForward extends ClawTransformation {
             promotionInfo.readDimensionsFromString(
                 pBase.getAttribute(Xattr.PROMOTION_INFO));
 
-            String type = _localFct ? Type.duplicateWithDimension(typeBase,
+            FbasicType type = _localFct ? Type.duplicateWithDimension(typeBase,
                 typeToUpdate, xcodeml, xcodeml, promotionInfo.getDimensions())
                 : Type.duplicateWithDimension(typeBase, typeToUpdate, _mod,
                 xcodeml, promotionInfo.getDimensions());

--- a/cx2t/src/claw/wani/x2t/configuration/Configuration.java
+++ b/cx2t/src/claw/wani/x2t/configuration/Configuration.java
@@ -6,12 +6,14 @@ package claw.wani.x2t.configuration;
 
 import claw.ClawVersion;
 import claw.shenron.transformation.BlockTransformation;
+import claw.tatsu.TatsuConstant;
 import claw.tatsu.common.CompilerDirective;
 import claw.tatsu.common.Context;
 import claw.tatsu.common.Target;
 import claw.tatsu.directive.configuration.AcceleratorConfiguration;
 import claw.tatsu.directive.configuration.OpenAccConfiguration;
 import claw.tatsu.directive.configuration.OpenMpConfiguration;
+import claw.tatsu.xcodeml.xnode.Xname;
 import claw.wani.transformation.ClawBlockTransformation;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -87,6 +89,9 @@ public class Configuration {
   public static final String CPU_STRATEGY = "cpu_trans_strategy";
   public static final String CPU_STRATEGY_SINGLE = "single";
   public static final String CPU_STRATEGY_FUSION = "fusion";
+  // SCA configuration keys
+  public static final String SCA_ELEMENTAL_PROMOTION_ASSUMED =
+      "sca_elemental_promotion_assumed";
   // env var
   private static final String CLAW_TRANS_SET_PATH = "CLAW_TRANS_SET_PATH";
 
@@ -375,6 +380,18 @@ public class Configuration {
    */
   public String getParameter(String key) {
     return (_parameters.containsKey(key)) ? _parameters.get(key) : null;
+  }
+
+  /**
+   * Get boolean value of a parameter.
+   *
+   * @param key Key of the parameter.
+   * @return Value of the parameter. False if parameter doesn't exists or its
+   * value is false.
+   */
+  public boolean getBooleanParameter(String key) {
+    return _parameters.containsKey(key)
+        && _parameters.get(key).equalsIgnoreCase(Xname.TRUE);
   }
 
   /**

--- a/cx2t/unittest/claw/tatsu/primitive/FieldTest.java
+++ b/cx2t/unittest/claw/tatsu/primitive/FieldTest.java
@@ -304,7 +304,7 @@ public class FieldTest {
       assertEquals(target, promotionInfo.getTargetDimension());
       assertEquals(base, promotionInfo.getBaseDimension());
       assertEquals(diff, promotionInfo.diffDimension());
-      assertEquals(bt.getType(), promotionInfo.getTargetType());
+      assertEquals(bt.getType(), promotionInfo.getTargetType().getType());
 
       if(base > 0) {
         assertEquals(PromotionInfo.PromotionType.ARRAY_TO_ARRAY,

--- a/driver/etc/claw-default.xml
+++ b/driver/etc/claw-default.xml
@@ -82,6 +82,15 @@ refer to the developer's guide
       - single: each assign statement is wrapped in a DO statement.
     -->
     <parameter key="cpu_trans_strategy" value="fusion" />
+
+    <!-- SCA defaults -->
+    <!-- 
+      How promotion is handle in SCA element function/subroutine. If true, 
+      newly added dimension are inserted as assumed shape and no new 
+      parameter is inserted in the function/subroutine signature. If false, 
+      the promotion is performed like in normal function/subroutine.
+    -->
+    <parameter key="sca_elemental_promotion_assumed" value="true" />
   </global>
 
   <!-- Transformation sets -->

--- a/driver/libexec/claw_f_lib.sh.in
+++ b/driver/libexec/claw_f_lib.sh.in
@@ -20,7 +20,6 @@ function claw::print_help() {
 usage: $1 <OPTIONS> <INPUTFILE> ...
 
 CLAW Compiler options:
-
    -o <file>                  : output file for the transformed FORTRAN code. If
                                 omitted, code output on the standard output.
    -I <dir>                   : add the directory dir to the list of directories
@@ -77,8 +76,7 @@ Decompiler options:
    -l                         : Add preprocessor line directives in the output
                                 FORTRAN file.
 
-Process Options
-
+Process options:
    --Wp[option] : Add preprocessor option.
    --Wf[option] : Add frontend option.
    --Wx[option] : Add Xcode translator option.

--- a/driver/libexec/claw_f_lib.sh.in
+++ b/driver/libexec/claw_f_lib.sh.in
@@ -67,7 +67,7 @@ CLAW Compiler options:
    --stop-frontend            : save intermediate files and stop after frontend.
    --stop-translator          : save intermediate files and stop after
                                 translator.
-   -x <config_key:value>      : override a configuration key:value pair from
+   -x=<config_key:value>      : override a configuration key:value pair from
                                 the command line. Higher priority over base
                                 configuration and user configuration.
 

--- a/test/claw/sca/CMakeLists.txt
+++ b/test/claw/sca/CMakeLists.txt
@@ -65,14 +65,17 @@ set(
 set(
   CLAW_FLAGS_sca41
   --model-config=${CMAKE_CURRENT_SOURCE_DIR}/sca41/model.toml
+  -x=sca_elemental_promotion_assumed:false
 )
 set(
   CLAW_FLAGS_sca43
   --model-config=${CMAKE_CURRENT_SOURCE_DIR}/sca43/model.toml
+  -x=sca_elemental_promotion_assumed:false
 )
 set(
   CLAW_FLAGS_sca45
   --model-config=${CMAKE_CURRENT_SOURCE_DIR}/sca45/model.toml
+  -x=sca_elemental_promotion_assumed:false
 )
 
 claw_add_advanced_test_set(


### PR DESCRIPTION
## Status
<!-- Choose one of the following -->
**IN DEVELOPMENT**

## Description
* Additional configuration for SCA transformation applied in ELEMENTAL function/subroutine. Sometimes, it is easier to use assumed shaped array and not insert new parameters for the lower bound/upper bound in the function/subroutine signature. This works only for subroutine or function in which the return value is not promoted. Return value cannot have a deferred shape. 

## Related issues
None
