### PR TITLE
Adaptation of SCA forward clause for ELEMENTAL

### DIFF
--- a/cx2t/src/claw/tatsu/common/Message.java
+++ b/cx2t/src/claw/tatsu/common/Message.java
@@ -17,8 +17,8 @@ import java.util.List;
  */
 public final class Message {
 
-  private static final String ERROR_PREFIX = "error: ";
-  private static final String WARNING_PREFIX = "warning: ";
+  private static final String ERROR_PREFIX = "error:";
+  private static final String WARNING_PREFIX = "warning:";
 
   // Avoid potential instantiation of this class
   private Message() {
@@ -47,10 +47,10 @@ public final class Message {
   {
     for(XanalysisError message : messages) {
       if(message.getLine() == 0) {
-        System.err.println(String.format("%s:-:- %s, %s", originalFile, prefix,
+        System.err.println(String.format("%s:-:- %s %s", originalFile, prefix,
             message.getMessage()));
       } else {
-        System.err.println(String.format("%s:%s:- %s, %s", originalFile,
+        System.err.println(String.format("%s:%s:- %s %s", originalFile,
             message.getConcatLines(), prefix, message.getMessage()));
       }
     }

--- a/cx2t/src/claw/tatsu/primitive/Xmod.java
+++ b/cx2t/src/claw/tatsu/primitive/Xmod.java
@@ -13,6 +13,7 @@ import claw.tatsu.xcodeml.xnode.fortran.*;
 import org.w3c.dom.Document;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -227,6 +228,13 @@ public final class Xmod {
         // Copy the promotion information
         pLocal.copyAttribute(pMod, Xattr.PROMOTION_INFO);
       }
+    }
+
+    // Sync attribute between local fct type and module fct type.
+    for(Xattr attr : Arrays.asList(Xattr.IS_ELEMENTAL, Xattr.IS_PURE,
+        Xattr.IS_FORCE_ASSUMED, Xattr.IS_RECURSIVE, Xattr.IS_PROGRAM,
+        Xattr.IS_INTERNAL)) {
+      fctType.syncBooleanAttribute(fctTypeMod, attr);
     }
   }
 }

--- a/cx2t/src/claw/tatsu/xcodeml/xnode/Xname.java
+++ b/cx2t/src/claw/tatsu/xcodeml/xnode/Xname.java
@@ -87,6 +87,7 @@ public final class Xname {
   // CLAW specific attribute used in FortranModule files
   public static final String ATTR_IS_INSERTED = "is_inserted";
   public static final String ATTR_PROMOTION_INFO = "promotion_info";
+  public static final String ATTR_IS_FORCE_ASSUMED = "is_force_assumed";
   // Element names
   public static final String ALLOC = "alloc";
   public static final String ALLOC_OPT = "allocOpt";
@@ -279,7 +280,6 @@ public final class Xname {
   public static final String ALLOCATE = "ALLOCATE";
   public static final String DEALLOCATE = "DEALLOCATE";
   public static final String GOTO = "GOTO";
-
 
   // Avoid instantiation of this class
   private Xname() {

--- a/cx2t/src/claw/tatsu/xcodeml/xnode/XnodeUtil.java
+++ b/cx2t/src/claw/tatsu/xcodeml/xnode/XnodeUtil.java
@@ -613,6 +613,11 @@ public class XnodeUtil {
 
     for(int i = 0; i < parameters.size(); ++i) {
       // TODO handle optional arguments, named value args
+
+      if(i >= arguments.size()) { // avoid getting args out of list
+        break;
+      }
+
       Xnode parameter = parameters.get(i);
       Xnode arg = arguments.get(i);
 

--- a/cx2t/src/claw/tatsu/xcodeml/xnode/XnodeUtil.java
+++ b/cx2t/src/claw/tatsu/xcodeml/xnode/XnodeUtil.java
@@ -585,6 +585,32 @@ public class XnodeUtil {
   }
 
   /**
+   * Gather string representation of the return value if there is one.
+   *
+   * @param xcodeml Current XcodeML translation unit.
+   * @param fctCall Function call to retrieve the return value.
+   * @return String representation of the return value if any. Null otherwise.
+   */
+  public static String gatherReturnValue(XcodeProgram xcodeml, Xnode fctCall) {
+    if(fctCall == null || fctCall.opcode() != Xcode.FUNCTION_CALL) {
+      return null;
+    }
+
+    Xnode fctCallAncestor = fctCall.matchAncestor(Xcode.F_ASSIGN_STATEMENT);
+    if(fctCallAncestor == null) {
+      return null;
+    }
+
+    Xnode returnNode = fctCallAncestor.firstChild();
+    if(xcodeml.getTypeTable().isBasicType(returnNode) &&
+        xcodeml.getTypeTable().getBasicType(returnNode).isArray())
+    {
+      return returnNode.constructRepresentation(false);
+    }
+    return null;
+  }
+
+  /**
    * Gather arguments of a function call.
    *
    * @param xcodeml       Current XcodeML translation unit.

--- a/cx2t/src/claw/tatsu/xcodeml/xnode/XnodeUtil.java
+++ b/cx2t/src/claw/tatsu/xcodeml/xnode/XnodeUtil.java
@@ -621,7 +621,7 @@ public class XnodeUtil {
       Xnode parameter = parameters.get(i);
       Xnode arg = arguments.get(i);
 
-      String rep = "";
+      String nodeRepresentation = "";
       if(FortranType.isBuiltInType(arg.getType()) && !arrayOnly
           && xcodeml.getTypeTable().isBasicType(parameter))
       {
@@ -629,7 +629,7 @@ public class XnodeUtil {
         if(!intent.isCompatible(btParameter.getIntent())) {
           continue;
         }
-        rep = arg.constructRepresentation(false);
+        nodeRepresentation = arg.constructRepresentation(false);
       } else if(xcodeml.getTypeTable().isBasicType(parameter)
           && xcodeml.getTypeTable().isBasicType(arg))
       {
@@ -640,10 +640,10 @@ public class XnodeUtil {
         {
           continue;
         }
-        rep = arg.constructRepresentation(false);
+        nodeRepresentation = arg.constructRepresentation(false);
       }
-      if(rep != null && !rep.isEmpty()) {
-        gatheredArguments.add(rep);
+      if(nodeRepresentation != null && !nodeRepresentation.isEmpty()) {
+        gatheredArguments.add(nodeRepresentation);
       }
     }
     return gatheredArguments;

--- a/cx2t/src/claw/tatsu/xcodeml/xnode/common/Xattr.java
+++ b/cx2t/src/claw/tatsu/xcodeml/xnode/common/Xattr.java
@@ -113,4 +113,8 @@ public enum Xattr {
   public String toString() {
     return _irValue;
   }
+
+  public String toStringForMsg() {
+    return _irValue.replaceAll("is_", "").toUpperCase();
+  }
 }

--- a/cx2t/src/claw/tatsu/xcodeml/xnode/common/Xattr.java
+++ b/cx2t/src/claw/tatsu/xcodeml/xnode/common/Xattr.java
@@ -87,7 +87,7 @@ public enum Xattr {
 
   // FortranModule extension to share promotion information
   IS_INSERTED(Xname.ATTR_IS_INSERTED),
-  IS_FORCE_ASSUMED(Xname.ATTR_FORCE_ASSUMED),
+  IS_FORCE_ASSUMED(Xname.ATTR_IS_FORCE_ASSUMED),
   PROMOTION_INFO(Xname.ATTR_PROMOTION_INFO);
 
   private static final Map<String, Xattr> _stringToEnum = new HashMap<>();

--- a/cx2t/src/claw/tatsu/xcodeml/xnode/common/Xattr.java
+++ b/cx2t/src/claw/tatsu/xcodeml/xnode/common/Xattr.java
@@ -87,6 +87,7 @@ public enum Xattr {
 
   // FortranModule extension to share promotion information
   IS_INSERTED(Xname.ATTR_IS_INSERTED),
+  IS_FORCE_ASSUMED(Xname.ATTR_FORCE_ASSUMED),
   PROMOTION_INFO(Xname.ATTR_PROMOTION_INFO);
 
   private static final Map<String, Xattr> _stringToEnum = new HashMap<>();

--- a/cx2t/src/claw/tatsu/xcodeml/xnode/common/XcodeML.java
+++ b/cx2t/src/claw/tatsu/xcodeml/xnode/common/XcodeML.java
@@ -832,6 +832,10 @@ public class XcodeML extends Xnode {
   public Xnode createAndAddParamIfNotExists(String nameValue, String type,
                                             FfunctionType fctType)
   {
+    if(fctType.isProgram()) {
+      return null;
+    }
+
     for(Xnode p : fctType.getParameters()) {
       if(p.value().equalsIgnoreCase(nameValue)) {
         return null;

--- a/cx2t/src/claw/tatsu/xcodeml/xnode/common/Xnode.java
+++ b/cx2t/src/claw/tatsu/xcodeml/xnode/common/Xnode.java
@@ -834,8 +834,9 @@ public class Xnode {
   }
 
   /**
+   * Set type of the node.
    *
-   * @param type
+   * @param type FbasicType to be associated with this node.
    */
   public void setType(FbasicType type) {
     setAttribute(Xattr.TYPE, type.getType());
@@ -962,6 +963,25 @@ public class Xnode {
   public void copyAttribute(Xnode to, Xattr attr) {
     if(hasAttribute(attr)) {
       to.setAttribute(attr, getAttribute(attr));
+    }
+  }
+
+  /**
+   * Sync given attribute between two node. Attribute present in this node
+   * is created in "to" if not present yet. Attribute not present in this node
+   * is removed from "to" if present.
+   *
+   * @param to        Node to which attribute is synced.
+   * @param attribute Attribute to be synced.
+   */
+  public void syncBooleanAttribute(Xnode to, Xattr attribute)
+  {
+    if(getBooleanAttribute(attribute) && !to.getBooleanAttribute(attribute)) {
+      to.setBooleanAttribute(attribute, true);
+    } else if(!getBooleanAttribute(attribute)
+        && to.getBooleanAttribute(attribute))
+    {
+      to.removeAttribute(attribute);
     }
   }
 

--- a/cx2t/src/claw/tatsu/xcodeml/xnode/fortran/FfunctionType.java
+++ b/cx2t/src/claw/tatsu/xcodeml/xnode/fortran/FfunctionType.java
@@ -4,6 +4,7 @@
  */
 package claw.tatsu.xcodeml.xnode.fortran;
 
+import claw.tatsu.xcodeml.xnode.Xname;
 import claw.tatsu.xcodeml.xnode.common.Xattr;
 import claw.tatsu.xcodeml.xnode.common.Xcode;
 import claw.tatsu.xcodeml.xnode.common.Xnode;
@@ -97,6 +98,26 @@ public class FfunctionType extends Xnode {
    */
   public boolean isPure() {
     return getBooleanAttribute(Xattr.IS_PURE);
+  }
+
+  /**
+   * Check if the function type is a subroutine.
+   *
+   * @return True if the function type is a subroutine.
+   */
+  public boolean isSubroutine() {
+    return getReturnType() == null
+        || getReturnType().equalsIgnoreCase(Xname.TYPE_F_VOID);
+  }
+
+  /**
+   * Check if the function type is a function.
+   *
+   * @return True if the function type is a subroutine.
+   */
+  public boolean isFunction() {
+    return getReturnType() != null
+        && !getReturnType().equalsIgnoreCase(Xname.TYPE_F_VOID);
   }
 
   /**

--- a/cx2t/src/claw/wani/transformation/sca/Sca.java
+++ b/cx2t/src/claw/wani/transformation/sca/Sca.java
@@ -341,8 +341,9 @@ public class Sca extends ClawTransformation {
   {
     if(fctType.hasAttribute(attribute)) {
       xcodeml.addWarning(String.format(
-          "SCA: attribute %s removed from function/subroutine %s",
-          attribute.toStringForMsg(), _fctDef.getName()), _claw.getPragma());
+          "%s attribute %s removed from function/subroutine %s",
+          SCA_DEBUG_PREFIX, attribute.toStringForMsg(), _fctDef.getName()),
+          _claw.getPragma());
       fctType.removeAttribute(attribute);
     }
   }

--- a/cx2t/src/claw/wani/transformation/sca/Sca.java
+++ b/cx2t/src/claw/wani/transformation/sca/Sca.java
@@ -348,6 +348,9 @@ public class Sca extends ClawTransformation {
     if(!_fctType.getBooleanAttribute(Xattr.IS_PRIVATE)) {
       FmoduleDefinition modDef = _fctDef.findParentModule();
       if(modDef != null) {
+        if(forceAssumedShapedArrayPromotion) {
+          _fctType.setBooleanAttribute(Xattr.IS_FORCE_ASSUMED, true);
+        }
         Xmod.updateSignature(modDef.getName(), xcodeml, _fctDef, _fctType,
             false);
       }

--- a/cx2t/src/claw/wani/transformation/sca/Sca.java
+++ b/cx2t/src/claw/wani/transformation/sca/Sca.java
@@ -302,16 +302,11 @@ public class Sca extends ClawTransformation {
       throws Exception
   {
     // Handle PURE function / subroutine
-    boolean pureRemoved = _fctType.isPure();
-    _fctType.removeAttribute(Xattr.IS_PURE);
-    if(Configuration.get().isForcePure() && pureRemoved) {
+    if(Configuration.get().isForcePure() && _fctType.isPure()) {
       throw new IllegalTransformationException(
           "PURE specifier cannot be removed", _fctDef.lineNo());
-    } else if(pureRemoved) {
-      String fctName = _fctDef.matchDirectDescendant(Xcode.NAME).value();
-      xcodeml.addWarning("PURE specifier removed from function " + fctName +
-              ". Transformation and code generation applied to it.",
-          _fctDef.lineNo());
+    } else {
+      removeAttributesWithWaring(xcodeml, _fctType, Xattr.IS_PURE);
     }
 
     // Insert the declarations of variables to iterate over the new dimensions.
@@ -332,6 +327,24 @@ public class Sca extends ClawTransformation {
     }
 
     removePragma();
+  }
+
+  /**
+   * Remove the given attribute if exists and add a warning.
+   *
+   * @param xcodeml   Current translation unit.
+   * @param fctType   Function type on which attribute is removed.
+   * @param attribute Attribute to remove.
+   */
+  void removeAttributesWithWaring(XcodeProgram xcodeml, FfunctionType fctType,
+                                  Xattr attribute)
+  {
+    if(fctType.hasAttribute(attribute)) {
+      xcodeml.addWarning(String.format(
+          "SCA: attribute %s removed from function/subroutine %s",
+          attribute.toStringForMsg(), _fctDef.getName()), _claw.getPragma());
+      fctType.removeAttribute(attribute);
+    }
   }
 
   /**

--- a/cx2t/src/claw/wani/transformation/sca/ScaForward.java
+++ b/cx2t/src/claw/wani/transformation/sca/ScaForward.java
@@ -584,7 +584,7 @@ public class ScaForward extends ClawTransformation {
 
     if(_claw.hasClause(ClawClause.CREATE) && Context.isTarget(Target.GPU)) {
       List<String> creates =
-          XnodeUtil.gatherArguments(xcodeml, _fctCall, Intent.INOUT, true);
+          XnodeUtil.gatherArguments(xcodeml, _fctCall, _fctType, _mod, Intent.INOUT, true);
       Directive.generateDataRegionClause(xcodeml,
           Collections.<String>emptyList(), creates,
           fctCallAncestor, fctCallAncestor);
@@ -595,7 +595,7 @@ public class ScaForward extends ClawTransformation {
           _claw.getUpdateClauseValue() == DataMovement.DEVICE)
       {
         List<String> out =
-            XnodeUtil.gatherArguments(xcodeml, _fctCall, Intent.IN, true);
+            XnodeUtil.gatherArguments(xcodeml, _fctCall, _fctType, _mod, Intent.IN, true);
         if(_claw.hasClause(ClawClause.UPDATE)) {
           Directive.generateUpdate(xcodeml, fctCallAncestor, out,
               DataMovement.DEVICE);
@@ -606,7 +606,7 @@ public class ScaForward extends ClawTransformation {
           _claw.getUpdateClauseValue() == DataMovement.HOST)
       {
         List<String> out =
-            XnodeUtil.gatherArguments(xcodeml, _fctCall, Intent.OUT, true);
+            XnodeUtil.gatherArguments(xcodeml, _fctCall, _fctType, _mod, Intent.OUT, true);
         if(_claw.hasClause(ClawClause.UPDATE)) {
           Directive.generateUpdate(xcodeml, fctCallAncestor,
               out, DataMovement.HOST);

--- a/cx2t/src/claw/wani/transformation/sca/ScaForward.java
+++ b/cx2t/src/claw/wani/transformation/sca/ScaForward.java
@@ -585,6 +585,14 @@ public class ScaForward extends ClawTransformation {
     if(_claw.hasClause(ClawClause.CREATE) && Context.isTarget(Target.GPU)) {
       List<String> creates = XnodeUtil.gatherArguments(xcodeml, _fctCall,
           _fctType, _mod, Intent.INOUT, true);
+
+      if(_fctType.isFunction()) {
+        String returnValue = XnodeUtil.gatherReturnValue(xcodeml, _fctCall);
+        if(returnValue != null) {
+          creates.add(returnValue);
+        }
+      }
+
       Directive.generateDataRegionClause(xcodeml,
           Collections.<String>emptyList(), creates,
           fctCallAncestor, fctCallAncestor);
@@ -605,6 +613,14 @@ public class ScaForward extends ClawTransformation {
       {
         List<String> out = XnodeUtil.gatherArguments(xcodeml, _fctCall,
             _fctType, _mod, Intent.OUT, true);
+
+        if(_fctType.isFunction()) {
+          String returnValue = XnodeUtil.gatherReturnValue(xcodeml, _fctCall);
+          if(returnValue != null) {
+            out.add(returnValue);
+          }
+        }
+
         Directive.generateUpdate(xcodeml, fctCallAncestor,
             out, DataMovement.HOST);
       }

--- a/cx2t/src/claw/wani/transformation/sca/ScaForward.java
+++ b/cx2t/src/claw/wani/transformation/sca/ScaForward.java
@@ -556,16 +556,20 @@ public class ScaForward extends ClawTransformation {
       if(!parentFctType.getBooleanAttribute(Xattr.IS_PRIVATE)) {
         // 3. Replicate the change in a potential module file
         FmoduleDefinition modDef = fDef.findParentModule();
-        Xmod.updateSignature(modDef.getName(), xcodeml, fDef, parentFctType,
-            false);
+        if(modDef != null) {
+          Xmod.updateSignature(modDef.getName(), xcodeml, fDef, parentFctType,
+              false);
+        }
       } else if(_fctCall.matchSeq(Xcode.NAME).hasAttribute(Xattr.DATA_REF)) {
         /* The function/subroutine is private but accessible through the type
          * as a type-bound procedure. In this case, the function is not in the
          * type table of the .xmod file. We need to insert it first and then
          * we can update it. */
         FmoduleDefinition modDef = fDef.findParentModule();
-        Xmod.updateSignature(modDef.getName(), xcodeml, fDef, parentFctType,
-            true);
+        if(modDef != null) {
+          Xmod.updateSignature(modDef.getName(), xcodeml, fDef, parentFctType,
+              true);
+        }
       }
     }
 

--- a/cx2t/src/claw/wani/transformation/sca/ScaForward.java
+++ b/cx2t/src/claw/wani/transformation/sca/ScaForward.java
@@ -583,8 +583,8 @@ public class ScaForward extends ClawTransformation {
     }
 
     if(_claw.hasClause(ClawClause.CREATE) && Context.isTarget(Target.GPU)) {
-      List<String> creates =
-          XnodeUtil.gatherArguments(xcodeml, _fctCall, _fctType, _mod, Intent.INOUT, true);
+      List<String> creates = XnodeUtil.gatherArguments(xcodeml, _fctCall,
+          _fctType, _mod, Intent.INOUT, true);
       Directive.generateDataRegionClause(xcodeml,
           Collections.<String>emptyList(), creates,
           fctCallAncestor, fctCallAncestor);
@@ -594,23 +594,19 @@ public class ScaForward extends ClawTransformation {
       if(_claw.getUpdateClauseValue() == DataMovement.BOTH ||
           _claw.getUpdateClauseValue() == DataMovement.DEVICE)
       {
-        List<String> out =
-            XnodeUtil.gatherArguments(xcodeml, _fctCall, _fctType, _mod, Intent.IN, true);
-        if(_claw.hasClause(ClawClause.UPDATE)) {
-          Directive.generateUpdate(xcodeml, fctCallAncestor, out,
-              DataMovement.DEVICE);
-        }
+        List<String> out = XnodeUtil.gatherArguments(xcodeml, _fctCall,
+            _fctType, _mod, Intent.IN, true);
+        Directive.generateUpdate(xcodeml, fctCallAncestor, out,
+            DataMovement.DEVICE);
       }
 
-      if(_claw.getUpdateClauseValue() == DataMovement.BOTH ||
-          _claw.getUpdateClauseValue() == DataMovement.HOST)
+      if(_claw.getUpdateClauseValue() == DataMovement.BOTH
+          || _claw.getUpdateClauseValue() == DataMovement.HOST)
       {
-        List<String> out =
-            XnodeUtil.gatherArguments(xcodeml, _fctCall, _fctType, _mod, Intent.OUT, true);
-        if(_claw.hasClause(ClawClause.UPDATE)) {
-          Directive.generateUpdate(xcodeml, fctCallAncestor,
-              out, DataMovement.HOST);
-        }
+        List<String> out = XnodeUtil.gatherArguments(xcodeml, _fctCall,
+            _fctType, _mod, Intent.OUT, true);
+        Directive.generateUpdate(xcodeml, fctCallAncestor,
+            out, DataMovement.HOST);
       }
     }
   }

--- a/cx2t/src/claw/wani/transformation/sca/ScaGPU.java
+++ b/cx2t/src/claw/wani/transformation/sca/ScaGPU.java
@@ -241,25 +241,6 @@ public class ScaGPU extends Sca {
   }
 
   /**
-   * Remove the given attribute if exists and add a warning.
-   *
-   * @param xcodeml   Current translation unit.
-   * @param fctType   Function type on which attribute is removed.
-   * @param attribute Attribute to remove.
-   */
-  private void removeAttributesWithWaring(XcodeProgram xcodeml,
-                                          FfunctionType fctType,
-                                          Xattr attribute)
-  {
-    if(fctType.hasAttribute(attribute)) {
-      xcodeml.addWarning(String.format(
-          "SCA: attribute %s removed from function/subroutine %s",
-          attribute.toString(), _fctDef.getName()), _claw.getPragma());
-      fctType.removeAttribute(attribute);
-    }
-  }
-
-  /**
    * Apply specific transformation steps for GPU target.
    *
    * @param xcodeml Current translation unit.

--- a/cx2t/src/claw/wani/transformation/sca/ScaRoutine.java
+++ b/cx2t/src/claw/wani/transformation/sca/ScaRoutine.java
@@ -59,8 +59,9 @@ public class ScaRoutine extends Sca {
       _fctType.removeAttribute(Xattr.IS_ELEMENTAL);
 
       if(Directive.hasDirectives(_fctDef)) {
-        xcodeml.addWarning("Function/subroutine has some directives! " +
-                "Cannot insert new directives without breaking existing ones!",
+        xcodeml.addWarning(String.format("%s %s", SCA_DEBUG_PREFIX,
+            "Function/subroutine has some directives! " +
+                "Cannot insert new directives without breaking existing ones!"),
             _claw.getPragma());
       } else {
         Directive.addPragmasBefore(xcodeml, dirGen.getRoutineDirective(true),

--- a/cx2t/unittest/claw/tatsu/xcodeml/xnode/common/XnodeUtilTest.java
+++ b/cx2t/unittest/claw/tatsu/xcodeml/xnode/common/XnodeUtilTest.java
@@ -4,6 +4,7 @@
  */
 package claw.tatsu.xcodeml.xnode.common;
 
+import claw.tatsu.xcodeml.xnode.fortran.FfunctionType;
 import claw.tatsu.xcodeml.xnode.fortran.Intent;
 import claw.tatsu.xcodeml.abstraction.HoistedNestedDoStatement;
 import claw.tatsu.xcodeml.xnode.XnodeUtil;
@@ -68,8 +69,10 @@ public class XnodeUtilTest {
     Xnode fctCall = functionCalls.get(0);
     assertSame(fctCall.opcode(), Xcode.FUNCTION_CALL);
 
+    FfunctionType fctType = xcodeml.getTypeTable().getFunctionType(fctCall);
+
     List<String> allArguments =
-        XnodeUtil.gatherArguments(xcodeml, fctCall, Intent.ANY, false);
+        XnodeUtil.gatherArguments(xcodeml, fctCall, fctType, xcodeml, Intent.ANY, false);
     assertEquals(5, allArguments.size());
     assertEquals(arg1, allArguments.get(0));
     assertEquals(arg2, allArguments.get(1));
@@ -78,7 +81,7 @@ public class XnodeUtilTest {
     assertEquals(arg5, allArguments.get(4));
 
     List<String> inArguments =
-        XnodeUtil.gatherArguments(xcodeml, fctCall, Intent.IN, false);
+        XnodeUtil.gatherArguments(xcodeml, fctCall, fctType, xcodeml, Intent.IN, false);
     assertEquals(5, inArguments.size());
     assertEquals(arg1, inArguments.get(0));
     assertEquals(arg2, inArguments.get(1));
@@ -87,28 +90,28 @@ public class XnodeUtilTest {
     assertEquals(arg5, inArguments.get(4));
 
     List<String> outArguments =
-        XnodeUtil.gatherArguments(xcodeml, fctCall, Intent.OUT, false);
+        XnodeUtil.gatherArguments(xcodeml, fctCall, fctType, xcodeml, Intent.OUT, false);
     assertEquals(3, outArguments.size());
     assertEquals(arg2, outArguments.get(0));
     assertEquals(arg3, outArguments.get(1));
     assertEquals(arg4, outArguments.get(2));
 
     List<String> inArrayArguments =
-        XnodeUtil.gatherArguments(xcodeml, fctCall, Intent.IN, true);
+        XnodeUtil.gatherArguments(xcodeml, fctCall, fctType, xcodeml, Intent.IN, true);
     assertEquals(3, inArrayArguments.size());
     assertEquals(arg2, inArrayArguments.get(0));
     assertEquals(arg3, inArrayArguments.get(1));
     assertEquals(arg4, inArrayArguments.get(2));
 
     List<String> outArrayArguments =
-        XnodeUtil.gatherArguments(xcodeml, fctCall, Intent.OUT, true);
+        XnodeUtil.gatherArguments(xcodeml, fctCall, fctType, xcodeml, Intent.OUT, true);
     assertEquals(3, outArrayArguments.size());
     assertEquals(arg2, outArrayArguments.get(0));
     assertEquals(arg3, outArrayArguments.get(1));
     assertEquals(arg4, outArrayArguments.get(2));
 
     List<String> inOutArrayArguments =
-        XnodeUtil.gatherArguments(xcodeml, fctCall, Intent.INOUT, true);
+        XnodeUtil.gatherArguments(xcodeml, fctCall, fctType, xcodeml, Intent.INOUT, true);
     assertEquals(3, inOutArrayArguments.size());
     assertEquals(arg2, inOutArrayArguments.get(0));
     assertEquals(arg3, inOutArrayArguments.get(1));

--- a/driver/libexec/claw_f_lib.sh.in
+++ b/driver/libexec/claw_f_lib.sh.in
@@ -313,7 +313,7 @@ function claw::print_version() {
 function claw::status_message()
 {
   filepath=$2
-  filename=$(basename "${filepath%.*}")
+  filename=$(basename "${filepath}")
   echo "${filename}:$3:$4 $1: $5" >&2
 }
 

--- a/test/claw/sca/sca41/reference_main_acc.f90
+++ b/test/claw/sca/sca41/reference_main_acc.f90
@@ -9,9 +9,10 @@ PROGRAM test_abstraction1
  DO i = 1 , 20 , 1
   t ( i ) = 0.5 * i
  END DO
-!$acc data pcreate(t)
+!$acc data pcreate(t,q)
 !$acc update device(t)
  q = compute_point ( t , nproma = nproma )
+!$acc update host(q)
 !$acc end data
  PRINT * , sum ( q )
  PRINT * , sum ( t )

--- a/test/claw/sca/sca41/reference_main_omp.f90
+++ b/test/claw/sca/sca41/reference_main_omp.f90
@@ -9,9 +9,10 @@ PROGRAM test_abstraction1
  DO i = 1 , 20 , 1
   t ( i ) = 0.5 * i
  END DO
-!$omp target data map(alloc:t)
+!$omp target data map(alloc:t,q)
 !$omp target update to(t)
  q = compute_point ( t , nproma = nproma )
+!$omp target update from(q)
 !$omp end target data
  PRINT * , sum ( q )
  PRINT * , sum ( t )

--- a/test/claw/sca/sca43/reference_main_acc.f90
+++ b/test/claw/sca/sca43/reference_main_acc.f90
@@ -10,9 +10,10 @@ PROGRAM test_abstraction1
  DO i = 1 , 20 , 1
   t ( i ) = 0.5 * i
  END DO
-!$acc data pcreate(t,w)
+!$acc data pcreate(t,w,q)
 !$acc update device(t,w)
  q = compute_point ( t , nproma = nproma , w = w )
+!$acc update host(q)
 !$acc end data
  PRINT * , sum ( q )
  PRINT * , sum ( t )

--- a/test/claw/sca/sca43/reference_main_acc.f90
+++ b/test/claw/sca/sca43/reference_main_acc.f90
@@ -10,8 +10,8 @@ PROGRAM test_abstraction1
  DO i = 1 , 20 , 1
   t ( i ) = 0.5 * i
  END DO
-!$acc data pcreate(t)
-!$acc update device(t)
+!$acc data pcreate(t,w)
+!$acc update device(t,w)
  q = compute_point ( t , nproma = nproma , w = w )
 !$acc end data
  PRINT * , sum ( q )

--- a/test/claw/sca/sca43/reference_main_omp.f90
+++ b/test/claw/sca/sca43/reference_main_omp.f90
@@ -10,8 +10,8 @@ PROGRAM test_abstraction1
  DO i = 1 , 20 , 1
   t ( i ) = 0.5 * i
  END DO
-!$omp target data map(alloc:t)
-!$omp target update to(t)
+!$omp target data map(alloc:t,w)
+!$omp target update to(t,w)
  q = compute_point ( t , nproma = nproma , w = w )
 !$omp end target data
  PRINT * , sum ( q )

--- a/test/claw/sca/sca43/reference_main_omp.f90
+++ b/test/claw/sca/sca43/reference_main_omp.f90
@@ -10,9 +10,10 @@ PROGRAM test_abstraction1
  DO i = 1 , 20 , 1
   t ( i ) = 0.5 * i
  END DO
-!$omp target data map(alloc:t,w)
+!$omp target data map(alloc:t,w,q)
 !$omp target update to(t,w)
  q = compute_point ( t , nproma = nproma , w = w )
+!$omp target update from(q)
 !$omp end target data
  PRINT * , sum ( q )
  PRINT * , sum ( t )

--- a/test/claw/sca/sca45/reference_main_acc.f90
+++ b/test/claw/sca/sca45/reference_main_acc.f90
@@ -9,9 +9,10 @@ PROGRAM test_abstraction1
  DO i = 1 , 20 , 1
   t ( i ) = 0.5 * i
  END DO
-!$acc data pcreate(t)
+!$acc data pcreate(t,q)
 !$acc update device(t)
  q = compute_point ( t , nproma = nproma )
+!$acc update host(q)
 !$acc end data
  PRINT * , sum ( q )
  PRINT * , sum ( t )

--- a/test/claw/sca/sca45/reference_main_omp.f90
+++ b/test/claw/sca/sca45/reference_main_omp.f90
@@ -9,9 +9,10 @@ PROGRAM test_abstraction1
  DO i = 1 , 20 , 1
   t ( i ) = 0.5 * i
  END DO
-!$omp target data map(alloc:t)
+!$omp target data map(alloc:t,q)
 !$omp target update to(t)
  q = compute_point ( t , nproma = nproma )
+!$omp target update from(q)
 !$omp end target data
  PRINT * , sum ( q )
  PRINT * , sum ( t )


### PR DESCRIPTION
## Status
<!-- Choose one of the following -->
**REVIEW**

## Description
* When `sca_elemental_promotion_assumed` is used, forward should not add any argument to fit/sub call. 

* Handle return value in `create` and `update` clauses.
