### PR TITLE
Fix cray preprocessor filename in dependency resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Change Log
 All notable changes to the CLAW Compiler project are documented in this file.
 
-## [1.2.2] - 2019-04-19
+## [1.2.3] - 2019-04-10
+* driver: fix preprocessor filename for Cray in dependency resolver
+
+## [1.2.2] - 2019-03-29
 * driver: fix temporary file name being too long in some cases.
 
 ## [1.2.1] - 2018-11-16

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.0)
 
-project("CLAW Compiler" VERSION 1.2.2)
+project("CLAW Compiler" VERSION 1.2.3)
 
 # Add local cmake modules
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/module")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![CLAW Logo](resources/logo_full_black.png)
 
-<a target="_blank" href="http://semver.org">![Version](https://img.shields.io/badge/Version-1.2.2-lightgray.svg)</a> [![Build Status](https://travis-ci.org/claw-project/claw-compiler.svg?branch=master)](https://travis-ci.org/claw-project/claw-compiler)
+<a target="_blank" href="http://semver.org">![Version](https://img.shields.io/badge/Version-1.2.3-lightgray.svg)</a> [![Build Status](https://travis-ci.org/claw-project/claw-compiler.svg?branch=master)](https://travis-ci.org/claw-project/claw-compiler)
 <a target="_blank" href="https://claw-compiler.slack.com/">![Slack](https://img.shields.io/badge/Collab-Slack-yellow.svg)</a>
 <a target="_blank" href="https://claw-project.github.io/claw-documentation/">![Doc](https://img.shields.io/badge/Documentation-link-lightgray.svg)</a>
 

--- a/driver/libexec/claw_f_lib.sh.in
+++ b/driver/libexec/claw_f_lib.sh.in
@@ -706,6 +706,8 @@ function claw::process_dependencies() {
 
     ### Preprocess file ###
     base_file=${source_mod_file}
+    dep_basename="$(basename "${base_file%.*}")"
+
     # shellcheck disable=SC2154
     local file_pp
     file_pp="$(claw::get_pp_filename "${base_file}")"


### PR DESCRIPTION
## Status
<!-- Choose one of the following -->
**REVIEW**

## Description
* Fix cray preprocessor filename in dependency resolver
* Bump to version 1.2.3
