### PR TITLE
Preparation for release 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Change Log
 All notable changes to the CLAW Compiler project are documented in this file.
 
-## [2.0] - Unreleased
+## [2.0] - 2019-08-23
 * `array-transform` directive as been renamed `expand` as specified in v2.0 of
   the CLAW Directive Language Specification.
 * `parallel` clause for `expand` directive is implemented.
 * `update` clause for `expand` directive is implemented.
 * beta serialization support for `expand` and `sca` elemental directives.
+  * Support Serialbox 2 at the moment (https://github.com/eth-cscs/serialbox2)
 * SCA: support for transformation in ELEMENTAL function/subroutine for
   GPU target
 * low-level: block directive like `loop-hoist` can now be nested on the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,16 @@
 All notable changes to the CLAW Compiler project are documented in this file.
 
 ## [2.0] - Unreleased
+* `array-transform` directive as been renamed `expand` as specified in v2.0 of
+  the CLAW Directive Language Specification.
+* `parallel` clause for `expand` directive is implemented.
+* `update` clause for `expand` directive is implemented.
+* beta serialization support for `expand` and `sca` elemental directives.
 * SCA: support for transformation in ELEMENTAL function/subroutine for
   GPU target
 * low-level: block directive like `loop-hoist` can now be nested on the same
   depth.
 * driver: `_CRAYFTN` macro is passed directly when Cray preprocessor is used.
-* `array-transform` directive as been renamed `expand` as specified in v2.0 of
-  the CLAW Directive Language Specification.
-* `parallel` clause for `expand` directive is implemented.
 * OMNI Compiler submodule now pointing to
   omni-compiler/xcodeml-tools@772cf79077ac5f04cfc204fc7e0b53755a362d8b
 * Java 1.8 or newer is now required for CX2T.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.0)
 
-project("CLAW Compiler" VERSION 1.2.3)
+project("CLAW Compiler" VERSION 2.0)
 
 # Add local cmake modules
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/module")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![CLAW Logo](resources/logo_full_black.png)
 
-<a target="_blank" href="http://semver.org">![Version](https://img.shields.io/badge/Version-1.2.3-lightgray.svg)</a> [![Build Status](https://travis-ci.org/claw-project/claw-compiler.svg?branch=master)](https://travis-ci.org/claw-project/claw-compiler)
+<a target="_blank" href="http://semver.org">![Version](https://img.shields.io/badge/Version-2.0-lightgray.svg)</a> [![Build Status](https://travis-ci.org/claw-project/claw-compiler.svg?branch=master)](https://travis-ci.org/claw-project/claw-compiler)
 <a target="_blank" href="https://claw-compiler.slack.com/">![Slack](https://img.shields.io/badge/Collab-Slack-yellow.svg)</a>
 <a target="_blank" href="https://claw-project.github.io/">![Doc](https://img.shields.io/badge/Documentation-link-lightgray.svg)</a>
 ![](https://img.shields.io/spack/v/claw.svg)

--- a/cx2t/src/claw/tatsu/directive/generator/OpenMp.java
+++ b/cx2t/src/claw/tatsu/directive/generator/OpenMp.java
@@ -361,8 +361,9 @@ public class OpenMp extends DirectiveGenerator {
     Message.debug(OPENMP_DEBUG_PREFIX + "generate update " +
         (direction == DataMovement.HOST_TO_DEVICE ? OPENMP_TO : OPENMP_FROM) +
         " clause for: " + String.join(",", vars));
-    String updates = String.format(FORMATPAR, direction == DataMovement.HOST_TO_DEVICE ?
-        OPENMP_TO : OPENMP_FROM, String.join(",", vars));
+    String updates =
+        String.format(FORMATPAR, direction == DataMovement.HOST_TO_DEVICE ?
+            OPENMP_TO : OPENMP_FROM, String.join(",", vars));
     return new String[]{
         String.format(FORMAT4,
             OPENMP_PREFIX, OPENMP_TARGET, OPENMP_UPDATE, updates)

--- a/cx2t/src/claw/tatsu/primitive/Field.java
+++ b/cx2t/src/claw/tatsu/primitive/Field.java
@@ -98,7 +98,8 @@ public final class Field {
       fieldInfo.setPromotionType(PromotionInfo.PromotionType.SCALAR_TO_ARRAY);
       Intent newIntent = crtType != null ? crtType.getIntent() : Intent.NONE;
       if(returnTypePromotion) {
-        newType = xcodeml.createBasicType(type, crtType.getRef(), newIntent);
+        newType = xcodeml.createBasicType(type,
+            crtType != null ? crtType.getRef() : "", newIntent);
       } else {
         newType = xcodeml.createBasicType(type, id.getType(), newIntent);
       }

--- a/cx2t/src/claw/tatsu/xcodeml/abstraction/Xblock.java
+++ b/cx2t/src/claw/tatsu/xcodeml/abstraction/Xblock.java
@@ -14,7 +14,7 @@ import claw.tatsu.xcodeml.xnode.common.Xnode;
  */
 public class Xblock {
 
-  private Xnode _startNode;
+  private final Xnode _startNode;
   private Xnode _endNode;
 
   public Xblock(Xnode start) {

--- a/cx2t/src/claw/wani/transformation/ll/loop/ExpandNotation.java
+++ b/cx2t/src/claw/wani/transformation/ll/loop/ExpandNotation.java
@@ -195,6 +195,12 @@ public class ExpandNotation extends ClawBlockTransformation {
         }
       }
 
+      if(doStmtsBlock == null) {
+        throw new IllegalTransformationException(
+            "Problem occurred during expand transformation",
+            _clawStart.getPragma().lineNo());
+      }
+
       Xblock parallelRegionBlock;
       Xblock updateRegionBlock = null;
       if(_clawStart.hasClause(ClawClause.PARALLEL)) {

--- a/cx2t/unittest/claw/wani/language/language/ClawPragmaTest.java
+++ b/cx2t/unittest/claw/wani/language/language/ClawPragmaTest.java
@@ -191,6 +191,7 @@ public class ClawPragmaTest {
                                                List<Target> targets)
   {
     ClawPragma l = analyze(raw, ClawDirective.LOOP_INTERCHANGE);
+    assertNotNull(l);
     if(indexes != null) {
       assertTrue(l.hasClause(ClawClause.INTERCHANGE_INDEXES));
       assertEquals(indexes.size(),

--- a/documentation/developer/code/claw-default.xml
+++ b/documentation/developer/code/claw-default.xml
@@ -1,4 +1,4 @@
-<claw version="1.0">
+<claw version="2.0">
   <!-- Global transformation parameters -->
   <global type="root">
     <!-- Define the translator to be used. -->

--- a/documentation/developer/code/extension_config.xml
+++ b/documentation/developer/code/extension_config.xml
@@ -1,4 +1,4 @@
-<claw version="1.0">
+<claw version="2.0">
   <global type="extension"/>
   <groups>
     <group name="remove"/>

--- a/documentation/developer/code/external_config.xml
+++ b/documentation/developer/code/external_config.xml
@@ -1,4 +1,4 @@
-<claw version="1.0">
+<claw version="2.0">
   <global type="root">
     <parameter key="translator" value="claw.wani.x2t.translator.ClawTranslator"/>
   </global>

--- a/documentation/developer/guide_claw_shenron.tex
+++ b/documentation/developer/guide_claw_shenron.tex
@@ -244,7 +244,7 @@ Listing~\ref{lst:new_trans_conf} uses the transformation set from
 Listing~\ref{lst:new_trans_set} and enables its only transformation.
 
 \begin{lstlisting}[label=lst:new_trans_conf, caption=claw-dummy.xml, language=xml]
-<claw version="1.0">
+<claw version="2.0">
   <global type="extension"/>
   <sets>
     <set name="claw-dummy"/>

--- a/documentation/manual/claw_fortran_compiler.tex
+++ b/documentation/manual/claw_fortran_compiler.tex
@@ -203,7 +203,7 @@ An option allows to use a different configuration while using the compiler.
 
 \begin{lstlisting}
   <!-- CLAW default configuration. This file should not be edited ! -->
-  <claw version="1.0">
+  <claw version="2.0">
     <!-- Transformation parameters -->
     <global>
       <!-- Default general values -->

--- a/driver/etc/claw-default.xml
+++ b/driver/etc/claw-default.xml
@@ -3,7 +3,7 @@ CLAW default configuration. This file should not be edited!
 For more information about the configuration file and its extension, please
 refer to the developer's guide
 -->
-<claw version="1.0">
+<claw version="2.0">
   <!-- Global transformation parameters -->
   <global type="root">
     <!-- Define the translator to be used. -->

--- a/test/claw/sca/sca32/promote.xml
+++ b/test/claw/sca/sca32/promote.xml
@@ -2,7 +2,7 @@
  This file is released under terms of BSD license
  See LICENSE file for more information
 -->
-<claw version="1.0">
+<claw version="2.0">
   <global type="extension">
     <!-- Override default behavior -->
     <parameter key="accelerator_local_strategy" value="promote" />

--- a/test/claw/sca/sca33/enable_collapse.xml
+++ b/test/claw/sca/sca33/enable_collapse.xml
@@ -1,4 +1,4 @@
-<claw version="1.0">
+<claw version="2.0">
   <!-- This configuration is just an extension of the default one -->
   <global type="extension">
     <parameter key="accelerator_collapse" value="true" />

--- a/test/driver/external1/external_config.xml
+++ b/test/driver/external1/external_config.xml
@@ -1,4 +1,4 @@
-<claw version="1.0">
+<claw version="2.0">
   <global type="root">
     <parameter key="translator" value="claw.wani.x2t.translator.ClawTranslator"/>
   </global>

--- a/test/loops/fusion10/fusion_first.xml
+++ b/test/loops/fusion10/fusion_first.xml
@@ -2,7 +2,7 @@
  This file is released under terms of BSD license
  See LICENSE file for more information
 -->
-<claw version="1.0">
+<claw version="2.0">
   <global type="extension"/>
   <groups>
     <group name="remove"/>

--- a/test/loops/fusion11/dedicated_config.xml
+++ b/test/loops/fusion11/dedicated_config.xml
@@ -1,4 +1,4 @@
-<claw version="1.0">
+<claw version="2.0">
   <!-- This configuration is just an extension of the default one -->
   <global type="extension"/>
   <groups>


### PR DESCRIPTION
## Status
<!-- Choose one of the following -->
**IN DEVELOPMENT**

## Description
* `array-transform` directive as been renamed `expand` as specified in v2.0 of
  the CLAW Directive Language Specification.
* `parallel` clause for `expand` directive is implemented.
* `update` clause for `expand` directive is implemented.
* beta serialization support for `expand` and `sca` elemental directives.
* SCA: support for transformation in ELEMENTAL function/subroutine for
  GPU target
* low-level: block directive like `loop-hoist` can now be nested on the same
  depth.
* driver: `_CRAYFTN` macro is passed directly when Cray preprocessor is used.
* `array-transform` directive as been renamed `expand` as specified in v2.0 of
  the CLAW Directive Language Specification.
* `parallel` clause for `expand` directive is implemented.
* OMNI Compiler submodule now pointing to
  omni-compiler/xcodeml-tools@772cf79077ac5f04cfc204fc7e0b53755a362d8b
* Java 1.8 or newer is now required for CX2T.
