### PR TITLE
clawfc option --no-module-cache

### DIFF
--- a/driver/bin/clawfc.in
+++ b/driver/bin/clawfc.in
@@ -56,6 +56,7 @@ pipe_workflow=true
 keep_comment=false
 add_paren=false
 omni_ffront_debug=false
+omni_ffront_no_module_cache=false
 
 ### Warning switches
 warn_dep_solver=false
@@ -125,6 +126,7 @@ readonly pipe_workflow
 readonly keep_comment
 readonly add_paren
 readonly omni_ffront_debug
+readonly omni_ffront_no_module_cache
 
 ### sed constant ###
 readonly claw_sed_ignore="s/\\!\$claw ignore//"
@@ -167,6 +169,10 @@ fi
 ### Add front-end option to keep the comment
 if [[ ${keep_comment} == true ]]; then
   OMNI_F2X_OPT="${OMNI_F2X_OPT} -fleave-comment"
+fi
+
+if [[ ${omni_ffront_no_module_cache} == true ]]; then
+  OMNI_F2X_OPT="${OMNI_F2X_OPT} -no-module-cache"
 fi
 
 readonly OMNI_F2X_OPT

--- a/driver/libexec/claw_f_lib.sh.in
+++ b/driver/libexec/claw_f_lib.sh.in
@@ -48,6 +48,7 @@ CLAW Compiler options:
    --show-env                 : show environment variables.
    --no-dep                   : don't generate .mod or .xmod file for
                                 dependencies.
+   --no-module-cache          : Deactivate module cache in the front-end.
    -f,--force                 : force the translation of files without
                                 directives.
    --force-pure               : force compiler to exit when transformation
@@ -191,9 +192,8 @@ function claw::set_parameters() {
       enable_debug_omni=true
       pipe_workflow=false
       ;;
-    --debug-ffront)
-      omni_ffront_debug=true
-      ;;
+    --debug-ffront) omni_ffront_debug=true ;;
+    --no-module-cache) omni_ffront_no_module_cache=true ;;
     --stop-pp)
       verbose=true
       stop_pp=true


### PR DESCRIPTION
## Status
<!-- Choose one of the following -->
**REVIEW**

## Description
* Add option `--no-module-cache` to deactivate the front-end module cache from clawfc
 