### PR TITLE
ADD: possibility to use CMAKE_C_FLAGS=" "

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,8 +90,8 @@ if(BUILD_OMNI)
         ${OMNI_COMPILER_SUBMODULE}/Makefile.in
       && CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER}
       FC=${CMAKE_Fortran_COMPILER} JAVAC=${Java_JAVAC_EXECUTABLE}
-      ${OMNI_COMPILER_SUBMODULE}/configure
       CFLAGS=${CMAKE_C_FLAGS}
+      ${OMNI_COMPILER_SUBMODULE}/configure
       --prefix=${CMAKE_INSTALL_PREFIX} ${OMNI_TARGET} ${OMNI_CONF_OPTION}
       ${OMNI_MPI_CC} ${OMNI_MPI_FC}
     BUILD_COMMAND make -j 1 # Not safe yet with -j

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ if(BUILD_OMNI)
       && CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER}
       FC=${CMAKE_Fortran_COMPILER} JAVAC=${Java_JAVAC_EXECUTABLE}
       ${OMNI_COMPILER_SUBMODULE}/configure
+      CFLAGS=${CMAKE_C_FLAGS}
       --prefix=${CMAKE_INSTALL_PREFIX} ${OMNI_TARGET} ${OMNI_CONF_OPTION}
       ${OMNI_MPI_CC} ${OMNI_MPI_FC}
     BUILD_COMMAND make -j 1 # Not safe yet with -j


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

## Description
The compilation of the omnicompiler uses a c99 compiler. The possibility to use the CMAKE_C_FLAGS in order to set the "-stc=c99" would be therefore useful in case one does not use a c99 compiler by default. The variable is then passed to the omnicompiler Autotools file via the CFLAGS=${CMAKE_C_FLAGS} command added to the main CMake file.

## Related issues
Issue #00 
Issue #01 

[100%] Performing build step for 'omni-compiler'
Created c-exprcode.h, c-exprcode.c
updating c-parser.h
updating c-parser.output
Created c-token.c, c-token.h
c-expr.c: In function ‘innerFreeExprOfBinaryNode’:
c-expr.c:2168:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
     for(int i = 0; i < 2; ++i)
     ^
c-expr.c:2168:5: note: use option -std=c99 or -std=gnu99 to compile your code
