### PR TITLE
Support Intel intrinsic module 'ifcore'.

### DIFF
--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -1,25 +1,32 @@
 # This file is released under terms of BSD license
 # See LICENSE file for more information
 
+# A list of .xmod files to be installed
+set(xmodFiles "")
+
 # Generate .xmod file module for common intrinsic libraries
 omni_generate_xmod(
   TARGET xmod-openacc SOURCE openacc_lib.f90 DEPENDS omni-compiler)
+list(APPEND xmodFiles ${CMAKE_CURRENT_BINARY_DIR}/openacc.xmod)
+
 omni_generate_xmod(
   TARGET xmod-ieee_features SOURCE ieee_features.f90 DEPENDS omni-compiler)
+list(APPEND xmodFiles ${CMAKE_CURRENT_BINARY_DIR}/ieee_features.xmod)
+
 omni_generate_xmod(
   TARGET xmod-ieee_exceptions SOURCE ieee_exceptions.f90 DEPENDS omni-compiler)
+list(APPEND xmodFiles ${CMAKE_CURRENT_BINARY_DIR}/ieee_exceptions.xmod)
+
 omni_generate_xmod(
   TARGET xmod-ieee_arithmetic SOURCE ieee_arithmetic.f90 DEPENDS omni-compiler)
-
 add_dependencies(xmod-ieee_arithmetic xmod-ieee_exceptions)
+list(APPEND xmodFiles ${CMAKE_CURRENT_BINARY_DIR}/ieee_arithmetic.xmod)
+
+if("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Intel")
+  omni_generate_xmod(
+    TARGET xmod-ifcore SOURCE intel/ifcore.f90 DEPENDS omni-compiler)
+  list(APPEND xmodFiles ${CMAKE_CURRENT_BINARY_DIR}/ifcore.xmod)
+endif()
 
 # Install in the intrinsic mod directory
-install(
-  FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/openacc.xmod
-    ${CMAKE_CURRENT_BINARY_DIR}/ieee_arithmetic.xmod
-    ${CMAKE_CURRENT_BINARY_DIR}/ieee_exceptions.xmod
-    ${CMAKE_CURRENT_BINARY_DIR}/ieee_features.xmod
-  DESTINATION
-    ${CMAKE_INSTALL_PREFIX}/fincludes
-)
+install(FILES ${xmodFiles} DESTINATION ${CMAKE_INSTALL_PREFIX}/fincludes)

--- a/modules/intel/ifcore.f90
+++ b/modules/intel/ifcore.f90
@@ -1,0 +1,22 @@
+! @author skosukhin
+! @brief  This file is used as a signatutre only module to generate .xmod file.
+!         These files are needed during a full parse with the OMNI Compiler.
+
+module ifcore
+
+  interface
+    subroutine tracebackqq(string, user_exit_code, status, eptr)
+      character*(*), intent(in), optional :: string
+      integer(4), intent(in), optional :: user_exit_code
+      integer(4), intent(out), optional :: status
+! eptr is of type POINTER - Integer:
+! https://software.intel.com/content/www/us/en/develop/documentation/fortran-compiler-developer-guide-and-reference/top/language-reference/a-to-z-reference/o-to-p/pointer-integer.html
+#if defined(__x86_64) || defined(__x86_64__)
+      integer(8), optional :: eptr
+#else
+      integer(4), optional :: eptr
+#endif
+    end subroutine
+  end interface
+
+end module


### PR DESCRIPTION
## Status
<!-- Choose one of the following -->
**REVIEW**

## Description
This allows for the compilation of code like this:
```fortran
#ifdef __INTEL_COMPILER
    USE ifcore, ONLY: tracebackqq
#endif
...
#ifdef __INTEL_COMPILER
    CALL tracebackqq
#endif
```
The original module obviously contains more but I suggest that we extend ours when needed.
