### PR TITLE
Fix for iterations space with automated model-data promotion

### DIFF
--- a/cx2t/src/claw/tatsu/primitive/Field.java
+++ b/cx2t/src/claw/tatsu/primitive/Field.java
@@ -130,18 +130,18 @@ public final class Field {
         for(DimensionDefinition dim : fieldInfo.getDimensions()) {
           switch(dim.getInsertionPosition()) {
             case BEFORE:
-              newType.addDimension(dim.generateIndexRange(xcodeml, false),
+              newType.addDimension(dim.generateIndexRange(xcodeml, false, false),
                   beforePositionIndex);
               ++beforePositionIndex;
               ++inMiddlePositionIndex; // Update index to insert in middle
               break;
             case IN_MIDDLE:
-              newType.addDimension(dim.generateIndexRange(xcodeml, false),
+              newType.addDimension(dim.generateIndexRange(xcodeml, false, false),
                   inMiddlePositionIndex);
               ++inMiddlePositionIndex;
               break;
             case AFTER:
-              newType.addDimension(dim.generateIndexRange(xcodeml, false));
+              newType.addDimension(dim.generateIndexRange(xcodeml, false, false));
               break;
           }
         }
@@ -152,7 +152,7 @@ public final class Field {
         if(fieldInfo.isForcedAssumedShape()) {
           index = xcodeml.createEmptyAssumedShaped();
         } else {
-          index = dim.generateIndexRange(xcodeml, false);
+          index = dim.generateIndexRange(xcodeml, false, false);
         }
         newType.addDimension(index);
       }

--- a/cx2t/src/claw/tatsu/primitive/Type.java
+++ b/cx2t/src/claw/tatsu/primitive/Type.java
@@ -59,10 +59,10 @@ public class Type {
         switch(dim.getInsertionPosition()) {
           case BEFORE:
             // TODO control and validate the before/after
-            newType.addDimension(dim.generateIndexRange(xcodemlDst, false));
+            newType.addDimension(dim.generateIndexRange(xcodemlDst, false, false));
             break;
           case AFTER:
-            newType.addDimension(dim.generateIndexRange(xcodemlDst, false), 0);
+            newType.addDimension(dim.generateIndexRange(xcodemlDst, false, false), 0);
             break;
           case IN_MIDDLE:
             throw new IllegalTransformationException("Not supported yet. " +

--- a/cx2t/src/claw/tatsu/xcodeml/abstraction/DimensionDefinition.java
+++ b/cx2t/src/claw/tatsu/xcodeml/abstraction/DimensionDefinition.java
@@ -214,33 +214,18 @@ public class DimensionDefinition {
    * @param xcodeml  Current XcodeML program unit in which elements will be
    *                 created.
    * @param withStep IF true, step element is created.
+   * @param useIteration IF true, use the iterations bounds instead of the size bounds.
    * @return A new indexRange elements.
    */
-  public Xnode generateIndexRange(XcodeML xcodeml, boolean withStep) {
+  public Xnode generateIndexRange(XcodeML xcodeml, boolean withStep, boolean useIteration) {
     Xnode range = xcodeml.createNode(Xcode.INDEX_RANGE);
-    range.append(_lowerBound.generate(xcodeml));
-    range.append(_upperBound.generate(xcodeml));
-    if(withStep) {
-      Xnode step = xcodeml.createNode(Xcode.STEP);
-      step.append(xcodeml.createIntConstant(DEFAULT_STEP_VALUE));
-      range.append(step);
+    if(useIteration) {
+      range.append(_iterationLowerBound.generate(xcodeml));
+      range.append(_iterationUpperBound.generate(xcodeml));
+    } else {
+      range.append(_lowerBound.generate(xcodeml));
+      range.append(_upperBound.generate(xcodeml));
     }
-    return range;
-  }
-
-  /**
-   * Generate the correct iterationRange element with iterationLowerBound,
-   * iterationUpperBound and step from the current dimension.
-   *
-   * @param xcodeml  Current XcodeML program unit in which elements will be
-   *                 created.
-   * @param withStep IF true, step element is created.
-   * @return A new indexRange elements.
-   */
-  public Xnode generateIterationRange(XcodeML xcodeml, boolean withStep) {
-    Xnode range = xcodeml.createNode(Xcode.INDEX_RANGE);
-    range.append(_iterationLowerBound.generate(xcodeml));
-    range.append(_iterationUpperBound.generate(xcodeml));
     if(withStep) {
       Xnode step = xcodeml.createNode(Xcode.STEP);
       step.append(xcodeml.createIntConstant(DEFAULT_STEP_VALUE));

--- a/cx2t/src/claw/tatsu/xcodeml/abstraction/DimensionDefinition.java
+++ b/cx2t/src/claw/tatsu/xcodeml/abstraction/DimensionDefinition.java
@@ -229,6 +229,27 @@ public class DimensionDefinition {
   }
 
   /**
+   * Generate the correct iterationRange element with iterationLowerBound,
+   * iterationUpperBound and step from the current dimension.
+   *
+   * @param xcodeml  Current XcodeML program unit in which elements will be
+   *                 created.
+   * @param withStep IF true, step element is created.
+   * @return A new indexRange elements.
+   */
+  public Xnode generateIterationRange(XcodeML xcodeml, boolean withStep) {
+    Xnode range = xcodeml.createNode(Xcode.INDEX_RANGE);
+    range.append(_iterationLowerBound.generate(xcodeml));
+    range.append(_iterationUpperBound.generate(xcodeml));
+    if(withStep) {
+      Xnode step = xcodeml.createNode(Xcode.STEP);
+      step.append(xcodeml.createIntConstant(DEFAULT_STEP_VALUE));
+      range.append(step);
+    }
+    return range;
+  }
+
+  /**
    * Generate the array index that will be placed in the array reference for
    * this additional dimension.
    *

--- a/cx2t/src/claw/tatsu/xcodeml/abstraction/NestedDoStatement.java
+++ b/cx2t/src/claw/tatsu/xcodeml/abstraction/NestedDoStatement.java
@@ -71,7 +71,7 @@ public class NestedDoStatement {
     for(DimensionDefinition dim : dimensions) {
       Xnode induction = xcodeml.createVar(FortranType.INTEGER,
           dim.getIdentifier(), Xscope.LOCAL);
-      Xnode range = dim.generateIndexRange(xcodeml, true);
+      Xnode range = dim.generateIterationRange(xcodeml, true);
       Xnode doStmt = xcodeml.createDoStmt(induction, range);
       if(!_statements.isEmpty()) {
         _statements.get(_statements.size() - 1).body().append(doStmt);

--- a/cx2t/src/claw/tatsu/xcodeml/abstraction/NestedDoStatement.java
+++ b/cx2t/src/claw/tatsu/xcodeml/abstraction/NestedDoStatement.java
@@ -71,7 +71,7 @@ public class NestedDoStatement {
     for(DimensionDefinition dim : dimensions) {
       Xnode induction = xcodeml.createVar(FortranType.INTEGER,
           dim.getIdentifier(), Xscope.LOCAL);
-      Xnode range = dim.generateIterationRange(xcodeml, true);
+      Xnode range = dim.generateIndexRange(xcodeml, true, true);
       Xnode doStmt = xcodeml.createDoStmt(induction, range);
       if(!_statements.isEmpty()) {
         _statements.get(_statements.size() - 1).body().append(doStmt);

--- a/cx2t/src/claw/wani/transformation/sca/Sca.java
+++ b/cx2t/src/claw/wani/transformation/sca/Sca.java
@@ -456,28 +456,32 @@ public class Sca extends ClawTransformation {
 
         // Create the parameter for the iteration lower bound
         if(dimension.getIterationLowerBound().isVar()) {
-          xcodeml.createIdAndDecl(dimension.getIterationLowerBound().getValue(),
-              bt.getType(), XstorageClass.F_PARAM, _fctDef,
-              DeclarationPosition.FIRST);
+	  String itLowerBound = dimension.getIterationLowerBound().getValue();
+	  if(!itLowerBound.equals(dimension.getLowerBound().getValue())) {
+	    xcodeml.createIdAndDecl(itLowerBound, bt.getType(),
+                XstorageClass.F_PARAM, _fctDef, DeclarationPosition.FIRST);
 
-          // Add parameter to the local type table
-          Xnode param = xcodeml.createAndAddParam(
-              dimension.getIterationLowerBound().getValue(),
-              bt.getType(), _fctType);
-          param.setBooleanAttribute(Xattr.IS_INSERTED, true);
+            // Add parameter to the local type table
+            Xnode param = xcodeml.createAndAddParam(
+                dimension.getIterationLowerBound().getValue(),
+                bt.getType(), _fctType);
+            param.setBooleanAttribute(Xattr.IS_INSERTED, true);
+	  }
         }
 
         // Create parameter for the upper bound
         if(dimension.getIterationUpperBound().isVar()) {
-          xcodeml.createIdAndDecl(dimension.getIterationUpperBound().getValue(),
-              bt.getType(), XstorageClass.F_PARAM, _fctDef,
-              DeclarationPosition.FIRST);
+	  String itUpperBound = dimension.getIterationUpperBound().getValue();
+	  if(!itUpperBound.equals(dimension.getUpperBound().getValue())) {
+            xcodeml.createIdAndDecl(itUpperBound, bt.getType(),
+                XstorageClass.F_PARAM, _fctDef, DeclarationPosition.FIRST);
 
-          // Add parameter to the local type table
-          Xnode param = xcodeml.createAndAddParam(
-              dimension.getIterationUpperBound().getValue(),
-              bt.getType(), _fctType);
-          param.setBooleanAttribute(Xattr.IS_INSERTED, true);
+            // Add parameter to the local type table
+            Xnode param = xcodeml.createAndAddParam(
+                dimension.getIterationUpperBound().getValue(),
+                bt.getType(), _fctType);
+            param.setBooleanAttribute(Xattr.IS_INSERTED, true);
+          }
         }
       }
       // Create induction variable declaration

--- a/cx2t/src/claw/wani/transformation/sca/Sca.java
+++ b/cx2t/src/claw/wani/transformation/sca/Sca.java
@@ -453,6 +453,32 @@ public class Sca extends ClawTransformation {
               bt.getType(), _fctType);
           param.setBooleanAttribute(Xattr.IS_INSERTED, true);
         }
+
+        // Create the parameter for the iteration lower bound
+        if(dimension.getIterationLowerBound().isVar()) {
+          xcodeml.createIdAndDecl(dimension.getIterationLowerBound().getValue(),
+              bt.getType(), XstorageClass.F_PARAM, _fctDef,
+              DeclarationPosition.FIRST);
+
+          // Add parameter to the local type table
+          Xnode param = xcodeml.createAndAddParam(
+              dimension.getIterationLowerBound().getValue(),
+              bt.getType(), _fctType);
+          param.setBooleanAttribute(Xattr.IS_INSERTED, true);
+        }
+
+        // Create parameter for the upper bound
+        if(dimension.getIterationUpperBound().isVar()) {
+          xcodeml.createIdAndDecl(dimension.getIterationUpperBound().getValue(),
+              bt.getType(), XstorageClass.F_PARAM, _fctDef,
+              DeclarationPosition.FIRST);
+
+          // Add parameter to the local type table
+          Xnode param = xcodeml.createAndAddParam(
+              dimension.getIterationUpperBound().getValue(),
+              bt.getType(), _fctType);
+          param.setBooleanAttribute(Xattr.IS_INSERTED, true);
+        }
       }
       // Create induction variable declaration
       xcodeml.createIdAndDecl(dimension.getIdentifier(), FortranType.INTEGER,

--- a/cx2t/unittest/claw/tatsu/primitive/LoopTest.java
+++ b/cx2t/unittest/claw/tatsu/primitive/LoopTest.java
@@ -66,9 +66,9 @@ public class LoopTest {
         "i", Xscope.LOCAL);
 
     Xnode l1 = xcodeml.createDoStmt(inductionI,
-        d1.generateIndexRange(xcodeml, true));
+        d1.generateIndexRange(xcodeml, true, false));
     Xnode l2 = xcodeml.createDoStmt(inductionI,
-        d1.generateIndexRange(xcodeml, true));
+        d1.generateIndexRange(xcodeml, true, false));
 
     List<FfunctionDefinition> fctDefs = xcodeml.getAllFctDef();
     assertFalse(fctDefs.isEmpty());

--- a/cx2t/unittest/claw/tatsu/xcodeml/abstraction/DimensionTest.java
+++ b/cx2t/unittest/claw/tatsu/xcodeml/abstraction/DimensionTest.java
@@ -53,14 +53,14 @@ public class DimensionTest {
     assertEquals(InsertionPosition.AFTER, dimDef.getInsertionPosition());
     assertEquals("nproma(1:nend)", dimDef.toString());
 
-    Xnode indexRange = dimDef.generateIndexRange(xcodeml, false);
+    Xnode indexRange = dimDef.generateIndexRange(xcodeml, false, false);
     assertNotNull(indexRange);
     assertEquals(Xcode.INDEX_RANGE, indexRange.opcode());
     assertEquals(2, indexRange.children().size());
     assertEquals(Xcode.LOWER_BOUND, indexRange.firstChild().opcode());
     assertEquals(Xcode.UPPER_BOUND, indexRange.lastChild().opcode());
 
-    Xnode indexRangeStep = dimDef.generateIndexRange(xcodeml, true);
+    Xnode indexRangeStep = dimDef.generateIndexRange(xcodeml, true, false);
     assertNotNull(indexRangeStep);
     assertEquals(Xcode.INDEX_RANGE, indexRangeStep.opcode());
     assertEquals(3, indexRangeStep.children().size());

--- a/test/claw/sca/CMakeLists.txt
+++ b/test/claw/sca/CMakeLists.txt
@@ -50,8 +50,9 @@
 # sca45: sca routine
 # sca46: simple RETURN transformation
 # sca47: Issue #578 regression
+# sca48: SCA with model config and separate size and iteration dimension variables
 
-foreach(loop_var RANGE 1 47)
+foreach(loop_var RANGE 1 48)
   if(NOT ${loop_var} EQUAL 30)
     set(CLAW_FLAGS_TARGET_CPU_sca${loop_var} --directive=none)
   endif()
@@ -79,6 +80,10 @@ set(
   CLAW_FLAGS_sca45
   --model-config=${CMAKE_CURRENT_SOURCE_DIR}/sca45/model.toml
   -x=sca_elemental_promotion_assumed:false
+)
+set(
+  CLAW_FLAGS_sca48
+  --model-config=${CMAKE_CURRENT_SOURCE_DIR}/iteration_size_model.toml
 )
 
 claw_add_advanced_test_set(

--- a/test/claw/sca/iteration_size_model.toml
+++ b/test/claw/sca/iteration_size_model.toml
@@ -1,0 +1,24 @@
+# SCA model configuration for regression tests with size and iteration
+# dimensions for the inserted "proma" dimension.
+
+[model] # Definition of global model information
+  name = "SCA"
+
+[[dimensions]] # Definition of dimensions that can be used in layouts
+  id = "p"
+  [dimensions.size]
+    lower = 1             # if not specified, 1 by default
+    upper = "nproma"      # mandatory information
+  [dimensions.iteration]
+    lower = "pstart"    # distinct start and
+    upper = "pend"      # end iteration variables
+
+[[dimensions]] # Add a new dimension in the hashtable
+  id = "k"
+  [dimensions.size]
+    upper = "nz"
+
+[[layouts]] # Definition of layouts and default layout for specific target
+  id = "default" # mandatory layout, used if no specific target layout
+                 # specified
+  position = [ "p", ":" ]

--- a/test/claw/sca/sca48/main.f90
+++ b/test/claw/sca/sca48/main.f90
@@ -1,0 +1,32 @@
+!
+! This file is released under terms of BSD license
+! See LICENSE file for more information
+!
+! Test the CLAW abstraction model with one additional dimension.
+!
+
+PROGRAM test_abstraction1
+  USE mo_column, ONLY: compute_column
+  REAL, DIMENSION(20,60) :: q, t  ! Fields as declared in the whole model
+  INTEGER :: nproma, nz           ! Size of array fields
+  INTEGER :: p                    ! Loop index
+  INTEGER :: pstart, pend         ! Loop bounds
+
+  nproma = 20
+  nz = 60
+  pstart = 1
+  pend = nproma
+
+  DO p = pstart, pend
+    q(p,1) = 0.0
+    t(p,1) = 0.0
+  END DO
+
+  !$claw sca forward create update
+  DO p = pstart, pend
+    CALL compute_column(nz, q(p,:), t(p,:))
+  END DO
+
+  PRINT*,SUM(q)
+  PRINT*,SUM(t)
+END PROGRAM test_abstraction1

--- a/test/claw/sca/sca48/mo_column.f90
+++ b/test/claw/sca/sca48/mo_column.f90
@@ -1,0 +1,36 @@
+!
+! This file is released under terms of BSD license
+! See LICENSE file for more information
+!
+
+MODULE mo_column
+  IMPLICIT NONE
+CONTAINS
+  ! Compute only one column
+  SUBROUTINE compute_column(nz, q, t)
+    IMPLICIT NONE
+
+    INTEGER, INTENT(IN)   :: nz   ! Size of the array field
+    !$claw model-data
+    REAL, INTENT(INOUT)   :: t(nz) ! Field declared as one column only
+    REAL, INTENT(INOUT)   :: q(nz) ! Field declared as one column only
+    !$claw end model-data
+    INTEGER :: k                  ! Loop index
+    REAL :: c                     ! Coefficient
+
+    ! CLAW definition
+
+    ! Define one dimension that will be added to the variables defined in the
+    ! data clause.
+    ! Apply the parallelization transformation on this subroutine.
+
+    !$claw sca
+
+    c = 5.345
+    DO k = 2, nz
+      t(k) = c * k
+      q(k) = q(k - 1)  + t(k) * c
+    END DO
+    q(nz) = q(nz) * c
+  END SUBROUTINE compute_column
+END MODULE mo_column

--- a/test/claw/sca/sca48/reference_acc.f90
+++ b/test/claw/sca/sca48/reference_acc.f90
@@ -1,0 +1,33 @@
+MODULE mo_column
+
+CONTAINS
+ SUBROUTINE compute_column ( nz , q , t , nproma , pstart , pend )
+  INTEGER , INTENT(IN) :: pend
+  INTEGER , INTENT(IN) :: pstart
+  INTEGER , INTENT(IN) :: nproma
+
+  INTEGER , INTENT(IN) :: nz
+  REAL , INTENT(INOUT) :: t ( 1 : nproma , 1 : nz )
+  REAL , INTENT(INOUT) :: q ( 1 : nproma , 1 : nz )
+  INTEGER :: k
+  REAL :: c
+  INTEGER :: p
+
+!$acc data present(t,q)
+!$acc parallel
+!$acc loop gang vector
+  DO p = pstart , pend , 1
+   c = 5.345
+!$acc loop seq
+   DO k = 2 , nz , 1
+    t ( p , k ) = c * k
+    q ( p , k ) = q ( p , k - 1 ) + t ( p , k ) * c
+   END DO
+   q ( p , nz ) = q ( p , nz ) * c
+  END DO
+!$acc end parallel
+!$acc end data
+ END SUBROUTINE compute_column
+
+END MODULE mo_column
+

--- a/test/claw/sca/sca48/reference_cpu.f90
+++ b/test/claw/sca/sca48/reference_cpu.f90
@@ -1,0 +1,29 @@
+MODULE mo_column
+
+CONTAINS
+ SUBROUTINE compute_column ( nz , q , t , nproma , pstart , pend )
+  INTEGER , INTENT(IN) :: pend
+  INTEGER , INTENT(IN) :: pstart
+  INTEGER , INTENT(IN) :: nproma
+
+  INTEGER , INTENT(IN) :: nz
+  REAL , INTENT(INOUT) :: t ( 1 : nproma , 1 : nz )
+  REAL , INTENT(INOUT) :: q ( 1 : nproma , 1 : nz )
+  INTEGER :: k
+  REAL :: c
+  INTEGER :: p
+
+  c = 5.345
+  DO k = 2 , nz , 1
+   DO p = pstart , pend , 1
+    t ( p , k ) = c * k
+    q ( p , k ) = q ( p , k - 1 ) + t ( p , k ) * c
+   END DO
+  END DO
+  DO p = pstart , pend , 1
+   q ( p , nz ) = q ( p , nz ) * c
+  END DO
+ END SUBROUTINE compute_column
+
+END MODULE mo_column
+

--- a/test/claw/sca/sca48/reference_main_acc.f90
+++ b/test/claw/sca/sca48/reference_main_acc.f90
@@ -1,0 +1,28 @@
+PROGRAM test_abstraction1
+ USE mo_column , ONLY: compute_column
+ REAL :: q ( 1 : 20 , 1 : 60 )
+ REAL :: t ( 1 : 20 , 1 : 60 )
+ INTEGER :: nproma
+ INTEGER :: nz
+ INTEGER :: p
+ INTEGER :: pstart
+ INTEGER :: pend
+
+ nproma = 20
+ nz = 60
+ pstart = 1
+ pend = nproma
+ DO p = pstart , pend , 1
+  q ( p , 1 ) = 0.0
+  t ( p , 1 ) = 0.0
+ END DO
+!$acc data pcreate(q(:,:),t(:,:))
+!$acc update device(q(:,:),t(:,:))
+ CALL compute_column ( nz , q ( : , : ) , t ( : , : ) , nproma = nproma ,&
+  pstart = pstart , pend = pend )
+!$acc update host(q(:,:),t(:,:))
+!$acc end data
+ PRINT * , sum ( q )
+ PRINT * , sum ( t )
+END PROGRAM test_abstraction1
+

--- a/test/claw/sca/sca48/reference_main_cpu.f90
+++ b/test/claw/sca/sca48/reference_main_cpu.f90
@@ -1,0 +1,24 @@
+PROGRAM test_abstraction1
+ USE mo_column , ONLY: compute_column
+ REAL :: q ( 1 : 20 , 1 : 60 )
+ REAL :: t ( 1 : 20 , 1 : 60 )
+ INTEGER :: nproma
+ INTEGER :: nz
+ INTEGER :: p
+ INTEGER :: pstart
+ INTEGER :: pend
+
+ nproma = 20
+ nz = 60
+ pstart = 1
+ pend = nproma
+ DO p = pstart , pend , 1
+  q ( p , 1 ) = 0.0
+  t ( p , 1 ) = 0.0
+ END DO
+ CALL compute_column ( nz , q ( : , : ) , t ( : , : ) , nproma = nproma ,&
+  pstart = pstart , pend = pend )
+ PRINT * , sum ( q )
+ PRINT * , sum ( t )
+END PROGRAM test_abstraction1
+

--- a/test/claw/sca/sca48/reference_main_omp.f90
+++ b/test/claw/sca/sca48/reference_main_omp.f90
@@ -1,0 +1,28 @@
+PROGRAM test_abstraction1
+ USE mo_column , ONLY: compute_column
+ REAL :: q ( 1 : 20 , 1 : 60 )
+ REAL :: t ( 1 : 20 , 1 : 60 )
+ INTEGER :: nproma
+ INTEGER :: nz
+ INTEGER :: p
+ INTEGER :: pstart
+ INTEGER :: pend
+
+ nproma = 20
+ nz = 60
+ pstart = 1
+ pend = nproma
+ DO p = pstart , pend , 1
+  q ( p , 1 ) = 0.0
+  t ( p , 1 ) = 0.0
+ END DO
+!$omp target data map(alloc:q(:,:),t(:,:))
+!$omp target update to(q(:,:),t(:,:))
+ CALL compute_column ( nz , q ( : , : ) , t ( : , : ) , nproma = nproma ,&
+  pstart = pstart , pend = pend )
+!$omp target update from(q(:,:),t(:,:))
+!$omp end target data
+ PRINT * , sum ( q )
+ PRINT * , sum ( t )
+END PROGRAM test_abstraction1
+

--- a/test/claw/sca/sca48/reference_omp.f90
+++ b/test/claw/sca/sca48/reference_omp.f90
@@ -1,0 +1,33 @@
+MODULE mo_column
+
+CONTAINS
+ SUBROUTINE compute_column ( nz , q , t , nproma , pstart , pend )
+  INTEGER , INTENT(IN) :: pend
+  INTEGER , INTENT(IN) :: pstart
+  INTEGER , INTENT(IN) :: nproma
+
+  INTEGER , INTENT(IN) :: nz
+  REAL , INTENT(INOUT) :: t ( 1 : nproma , 1 : nz )
+  REAL , INTENT(INOUT) :: q ( 1 : nproma , 1 : nz )
+  INTEGER :: k
+  REAL :: c
+  INTEGER :: p
+
+!$omp target
+!$omp teams
+!$omp distribute
+  DO p = pstart , pend , 1
+   c = 5.345
+   DO k = 2 , nz , 1
+    t ( p , k ) = c * k
+    q ( p , k ) = q ( p , k - 1 ) + t ( p , k ) * c
+   END DO
+   q ( p , nz ) = q ( p , nz ) * c
+  END DO
+!$omp end distribute
+!$omp end teams
+!$omp end target
+ END SUBROUTINE compute_column
+
+END MODULE mo_column
+


### PR DESCRIPTION
## Status
<!-- Choose one of the following -->
**REVIEW**

## Description
When using the new `!$claw model data` API for marking promotion variables in combination with a model-config file, the insertion of new loops in the CPU and GPU backends ignores any explicitly provided `[dimensions.iteration]` variables. This PR fixes this and adds a new test to demonstrate the correct insert of CPU and GPU loops over iteration ranges that are different to the provided size variables. In this test the loops inserted iteration over the range `DO p = pstart , pend, 1`, while the promoted variable dimension is `t ( 1 : nproma, nz)`.

