### PR TITLE
[sca] Fix issue #598

### DIFF
--- a/cx2t/src/claw/tatsu/directive/common/Directive.java
+++ b/cx2t/src/claw/tatsu/directive/common/Directive.java
@@ -502,9 +502,7 @@ public final class Directive {
                                               Xnode from)
   {
     DirectiveGenerator dg = Context.get().getGenerator();
-    if(dg.getDirectiveLanguage() == CompilerDirective.NONE
-        || !Xnode.isOfCode(functionDefinition, Xcode.F_FUNCTION_DEFINITION))
-    {
+    if(!Xnode.isOfCode(functionDefinition, Xcode.F_FUNCTION_DEFINITION)) {
       return null;
     }
     Xnode first = functionDefinition.body().firstChild();
@@ -572,9 +570,7 @@ public final class Directive {
   {
     DirectiveGenerator dg = Context.get().getGenerator();
 
-    if(dg.getDirectiveLanguage() == CompilerDirective.NONE
-        || !Xnode.isOfCode(functionDefinition, Xcode.F_FUNCTION_DEFINITION))
-    {
+    if(!Xnode.isOfCode(functionDefinition, Xcode.F_FUNCTION_DEFINITION)) {
       return null;
     }
     Xnode last = functionDefinition.body().lastChild();

--- a/test/claw/sca/CMakeLists.txt
+++ b/test/claw/sca/CMakeLists.txt
@@ -51,6 +51,7 @@
 # sca46: simple RETURN transformation
 # sca47: Issue #578 regression
 # sca48: SCA with model config and separate size and iteration dimension variables
+# sca49: Loop insertion issue with --directive=none (Issue #598)
 
 foreach(loop_var RANGE 1 48)
   if(NOT ${loop_var} EQUAL 30)
@@ -89,7 +90,13 @@ set(
 claw_add_advanced_test_set(
   NAME claw-sca
   DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  EXCLUDE sca30 sca44
+  EXCLUDE sca30 sca44 sca49
+)
+
+claw_add_basic_test(
+  NAME claw-sca-sca49
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/sca49
+  CLAW_FLAGS --directive=none
 )
 
 # Specific "fail" test to check correct failure

--- a/test/claw/sca/sca49/original_code.f90
+++ b/test/claw/sca/sca49/original_code.f90
@@ -1,0 +1,19 @@
+!
+! This file is released under terms of BSD license
+! See LICENSE file for more information
+!
+! Test case for issue #598
+module sca49
+  contains
+  subroutine sub1()
+    integer :: i, j
+    integer, parameter :: ny = 10, nx = 10
+
+    !$claw define dimension k(1:n_term) &
+    !$claw sca
+    do j=1, ny
+      do i=1, nx
+      end do
+    end do
+  end subroutine sub1
+end module

--- a/test/claw/sca/sca49/reference.f90
+++ b/test/claw/sca/sca49/reference.f90
@@ -1,0 +1,22 @@
+MODULE sca49
+
+CONTAINS
+ SUBROUTINE sub1 ( n_term )
+  INTEGER , INTENT(IN) :: n_term
+
+  INTEGER :: i
+  INTEGER :: j
+  INTEGER , PARAMETER :: ny = 10
+  INTEGER , PARAMETER :: nx = 10
+  INTEGER :: k
+
+  DO k = 1 , n_term , 1
+   DO j = 1 , 10 , 1
+    DO i = 1 , 10 , 1
+    END DO
+   END DO
+  END DO
+ END SUBROUTINE sub1
+
+END MODULE sca49
+


### PR DESCRIPTION
## Status
<!-- Choose one of the following -->
**REVIEW**

## Description
Fix #598. `findParallelRegionStart` and `findParallelRegionEnd` are used to determine the start and end insertion point for the DO statement. These functions were returning null if the directive was set to none. 

## Related issues
Issue #598 
