### PR TITLE
Fix the dependency preprocessing for Cray compiler

### DIFF
--- a/driver/libexec/claw_f_lib.sh.in
+++ b/driver/libexec/claw_f_lib.sh.in
@@ -773,13 +773,13 @@ function claw::process_dependencies() {
       mv "${file_pp1}" "${file_pp}"
     else
       local preprocessor_output
-      preprocessor_output="$(basename "${file_pp%.*}")"
+      preprocessor_output="$(basename "${file_pp%.*}").i"
 
       # shellcheck disable=SC2086,SC2068
       ${OMNI_FPP_CMD} ${include_opt[@]} ${pp_add_opt[@]} ${OMNI_FPP_OPT} \
-        ${other_args[@]} "${file_pp1}"
+        ${other_args[@]} "${file_pp}"
 
-      mv "${preprocessor_output}.i" "${file_pp}"
+      mv "${preprocessor_output}" "${file_pp}"
     fi
 
     # Recurse to get dependencies in the right order


### PR DESCRIPTION
## Status
**REVIEW**

## Description
This fixes a bug introduced in #579.

Note, however, that the problem described in https://github.com/omni-compiler/xcodeml-tools/issues/165 is also the case of the Cray Fortran preprocessor. We could fix that with an additional preprocessing step, i.e. we could replace
```fortran
 integer b ; &
# 42
&integer c
 integer d ;&
&integer e
 integer f ;&
 integer g
```
with
```fortran
 integer b 
integer c
 integer d 
integer e
 integer f 
 integer g
```